### PR TITLE
feat: 通知システム基盤実装（モジュール構造・エラー型・リクエスト）

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap_complete = "4.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+uuid = { version = "1.0", features = ["v4"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 colored = "2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@
 
 pub mod cli;
 pub mod daemon;
+pub mod notification;
 pub mod types;

--- a/src/notification/error.rs
+++ b/src/notification/error.rs
@@ -1,0 +1,111 @@
+//! 通知システムのエラー型定義
+
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotificationError {
+    AuthorizationFailed(String),
+    SendFailed(String),
+    PermissionDenied,
+    UnsignedBinary,
+    InitializationFailed(String),
+    InvalidInput(String),
+}
+
+impl fmt::Display for NotificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NotificationError::AuthorizationFailed(msg) => {
+                write!(f, "通知許可の取得に失敗しました: {}", msg)
+            }
+            NotificationError::SendFailed(msg) => {
+                write!(f, "通知の送信に失敗しました: {}", msg)
+            }
+            NotificationError::PermissionDenied => {
+                write!(f, "通知許可が拒否されています")
+            }
+            NotificationError::UnsignedBinary => {
+                write!(
+                    f,
+                    "バイナリが署名されていません。codesignで署名してください"
+                )
+            }
+            NotificationError::InitializationFailed(msg) => {
+                write!(f, "通知システムの初期化に失敗しました: {}", msg)
+            }
+            NotificationError::InvalidInput(msg) => {
+                write!(f, "無効な入力: {}", msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for NotificationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_authorization_failed_display() {
+        let error = NotificationError::AuthorizationFailed("timeout".to_string());
+        assert_eq!(error.to_string(), "通知許可の取得に失敗しました: timeout");
+    }
+
+    #[test]
+    fn test_send_failed_display() {
+        let error = NotificationError::SendFailed("network error".to_string());
+        assert_eq!(error.to_string(), "通知の送信に失敗しました: network error");
+    }
+
+    #[test]
+    fn test_permission_denied_display() {
+        let error = NotificationError::PermissionDenied;
+        assert_eq!(error.to_string(), "通知許可が拒否されています");
+    }
+
+    #[test]
+    fn test_unsigned_binary_display() {
+        let error = NotificationError::UnsignedBinary;
+        assert!(error.to_string().contains("codesign"));
+    }
+
+    #[test]
+    fn test_initialization_failed_display() {
+        let error = NotificationError::InitializationFailed("missing framework".to_string());
+        assert_eq!(
+            error.to_string(),
+            "通知システムの初期化に失敗しました: missing framework"
+        );
+    }
+
+    #[test]
+    fn test_invalid_input_display() {
+        let error = NotificationError::InvalidInput("タスク名が長すぎます".to_string());
+        assert_eq!(error.to_string(), "無効な入力: タスク名が長すぎます");
+    }
+
+    #[test]
+    fn test_error_equality() {
+        let error1 = NotificationError::PermissionDenied;
+        let error2 = NotificationError::PermissionDenied;
+        assert_eq!(error1, error2);
+
+        let error3 = NotificationError::UnsignedBinary;
+        assert_ne!(error1, error3);
+    }
+
+    #[test]
+    fn test_error_clone() {
+        let error = NotificationError::SendFailed("test".to_string());
+        let cloned = error.clone();
+        assert_eq!(error, cloned);
+    }
+
+    #[test]
+    fn test_error_debug() {
+        let error = NotificationError::PermissionDenied;
+        let debug_str = format!("{:?}", error);
+        assert!(debug_str.contains("PermissionDenied"));
+    }
+}

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -1,0 +1,129 @@
+//! 通知システムモジュール
+
+pub mod error;
+pub mod request;
+
+pub use error::NotificationError;
+pub use request::{NotificationRequest, NotificationRequestId};
+
+pub mod category_ids {
+    pub const WORK_COMPLETE: &str = "WORK_COMPLETE";
+    pub const BREAK_COMPLETE: &str = "BREAK_COMPLETE";
+    pub const LONG_BREAK_COMPLETE: &str = "LONG_BREAK_COMPLETE";
+}
+
+pub mod action_ids {
+    pub const PAUSE_ACTION: &str = "PAUSE_ACTION";
+    pub const STOP_ACTION: &str = "STOP_ACTION";
+}
+
+pub mod limits {
+    pub const MAX_TASK_NAME_LENGTH: usize = 100;
+    pub const MAX_TITLE_LENGTH: usize = 50;
+    pub const MAX_BODY_LENGTH: usize = 200;
+}
+
+/// # Errors
+/// - タスク名が100文字を超える場合
+/// - タスク名に制御文字が含まれる場合
+pub fn validate_task_name(task_name: &str) -> Result<&str, NotificationError> {
+    if task_name.len() > limits::MAX_TASK_NAME_LENGTH {
+        return Err(NotificationError::InvalidInput(format!(
+            "タスク名は{}文字以内にしてください",
+            limits::MAX_TASK_NAME_LENGTH
+        )));
+    }
+
+    if task_name.chars().any(|c| c.is_control()) {
+        return Err(NotificationError::InvalidInput(
+            "タスク名に制御文字は使用できません".to_string(),
+        ));
+    }
+
+    Ok(task_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_category_ids() {
+        assert_eq!(category_ids::WORK_COMPLETE, "WORK_COMPLETE");
+        assert_eq!(category_ids::BREAK_COMPLETE, "BREAK_COMPLETE");
+        assert_eq!(category_ids::LONG_BREAK_COMPLETE, "LONG_BREAK_COMPLETE");
+    }
+
+    #[test]
+    fn test_action_ids() {
+        assert_eq!(action_ids::PAUSE_ACTION, "PAUSE_ACTION");
+        assert_eq!(action_ids::STOP_ACTION, "STOP_ACTION");
+    }
+
+    #[test]
+    fn test_validate_task_name_valid() {
+        let result = validate_task_name("API実装");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "API実装");
+    }
+
+    #[test]
+    fn test_validate_task_name_too_long() {
+        let long_name = "a".repeat(101);
+        let result = validate_task_name(&long_name);
+        assert!(result.is_err());
+        match result {
+            Err(NotificationError::InvalidInput(msg)) => {
+                assert!(msg.contains("100文字以内"));
+            }
+            _ => panic!("Expected InvalidInput error"),
+        }
+    }
+
+    #[test]
+    fn test_validate_task_name_with_control_chars() {
+        let name_with_newline = "API\n実装";
+        let result = validate_task_name(name_with_newline);
+        assert!(result.is_err());
+        match result {
+            Err(NotificationError::InvalidInput(msg)) => {
+                assert!(msg.contains("制御文字"));
+            }
+            _ => panic!("Expected InvalidInput error"),
+        }
+    }
+
+    #[test]
+    fn test_validate_task_name_with_tab() {
+        let name_with_tab = "API\t実装";
+        let result = validate_task_name(name_with_tab);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_task_name_exact_limit() {
+        let exact_limit = "a".repeat(100);
+        let result = validate_task_name(&exact_limit);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_task_name_empty() {
+        let result = validate_task_name("");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_task_name_unicode() {
+        let unicode_name = "🍅ポモドーロタスク🎯";
+        let result = validate_task_name(unicode_name);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_re_exports() {
+        let _error = NotificationError::PermissionDenied;
+        let _request = NotificationRequest::new("title", "body", "category");
+        let _id = NotificationRequestId::new();
+    }
+}

--- a/src/notification/request.rs
+++ b/src/notification/request.rs
@@ -1,0 +1,172 @@
+//! 通知リクエストの作成
+
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NotificationRequestId(String);
+
+impl NotificationRequestId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    pub fn from_string(id: String) -> Self {
+        Self(id)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for NotificationRequestId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for NotificationRequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationRequest {
+    pub id: NotificationRequestId,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub body: String,
+    pub category_id: String,
+    pub play_sound: bool,
+}
+
+impl NotificationRequest {
+    pub fn new(
+        title: impl Into<String>,
+        body: impl Into<String>,
+        category_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: NotificationRequestId::new(),
+            title: title.into(),
+            subtitle: None,
+            body: body.into(),
+            category_id: category_id.into(),
+            play_sound: true,
+        }
+    }
+
+    pub fn with_subtitle(mut self, subtitle: impl Into<String>) -> Self {
+        self.subtitle = Some(subtitle.into());
+        self
+    }
+
+    pub fn with_sound(mut self, play_sound: bool) -> Self {
+        self.play_sound = play_sound;
+        self
+    }
+
+    pub fn with_id(mut self, id: NotificationRequestId) -> Self {
+        self.id = id;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_notification_request_id_new() {
+        let id1 = NotificationRequestId::new();
+        let id2 = NotificationRequestId::new();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_notification_request_id_from_string() {
+        let id = NotificationRequestId::from_string("test-id-123".to_string());
+        assert_eq!(id.as_str(), "test-id-123");
+    }
+
+    #[test]
+    fn test_notification_request_id_display() {
+        let id = NotificationRequestId::from_string("display-test".to_string());
+        assert_eq!(format!("{}", id), "display-test");
+    }
+
+    #[test]
+    fn test_notification_request_id_default() {
+        let id = NotificationRequestId::default();
+        assert!(!id.as_str().is_empty());
+    }
+
+    #[test]
+    fn test_notification_request_new() {
+        let request = NotificationRequest::new("タイトル", "本文", "CATEGORY_ID");
+        assert_eq!(request.title, "タイトル");
+        assert_eq!(request.body, "本文");
+        assert_eq!(request.category_id, "CATEGORY_ID");
+        assert!(request.subtitle.is_none());
+        assert!(request.play_sound);
+    }
+
+    #[test]
+    fn test_notification_request_with_subtitle() {
+        let request =
+            NotificationRequest::new("タイトル", "本文", "CATEGORY").with_subtitle("サブタイトル");
+        assert_eq!(request.subtitle, Some("サブタイトル".to_string()));
+    }
+
+    #[test]
+    fn test_notification_request_with_sound() {
+        let request = NotificationRequest::new("タイトル", "本文", "CATEGORY").with_sound(false);
+        assert!(!request.play_sound);
+    }
+
+    #[test]
+    fn test_notification_request_with_custom_id() {
+        let custom_id = NotificationRequestId::from_string("custom-123".to_string());
+        let request =
+            NotificationRequest::new("タイトル", "本文", "CATEGORY").with_id(custom_id.clone());
+        assert_eq!(request.id, custom_id);
+    }
+
+    #[test]
+    fn test_notification_request_builder_chain() {
+        let request = NotificationRequest::new("作業完了", "休憩してください", "WORK_COMPLETE")
+            .with_subtitle("API実装")
+            .with_sound(true);
+
+        assert_eq!(request.title, "作業完了");
+        assert_eq!(request.body, "休憩してください");
+        assert_eq!(request.category_id, "WORK_COMPLETE");
+        assert_eq!(request.subtitle, Some("API実装".to_string()));
+        assert!(request.play_sound);
+    }
+
+    #[test]
+    fn test_uuid_format() {
+        let id = NotificationRequestId::new();
+        let uuid_str = id.as_str();
+        assert_eq!(uuid_str.len(), 36);
+        assert_eq!(uuid_str.chars().nth(8), Some('-'));
+        assert_eq!(uuid_str.chars().nth(13), Some('-'));
+        assert_eq!(uuid_str.chars().nth(14), Some('4'));
+        assert_eq!(uuid_str.chars().nth(18), Some('-'));
+        assert_eq!(uuid_str.chars().nth(23), Some('-'));
+    }
+
+    #[test]
+    fn test_uuid_uniqueness() {
+        let mut uuids = std::collections::HashSet::new();
+        for _ in 0..100 {
+            let id = NotificationRequestId::new();
+            assert!(
+                uuids.insert(id.as_str().to_string()),
+                "UUID collision detected"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- macOS通知システムの基盤となるモジュール構造、エラー型、リクエスト型を実装

## Changes
- `src/notification/mod.rs`: モジュールエクスポート、定数（カテゴリID/アクションID）、`validate_task_name()`
- `src/notification/error.rs`: `NotificationError` enum（6バリアント）
- `src/notification/request.rs`: `NotificationRequest`（ビルダーパターン）、`NotificationRequestId`（UUID v4）
- `Cargo.toml`: `uuid` crate追加

## NotificationError Variants
| Variant | Description |
|---------|-------------|
| `AuthorizationFailed` | 通知許可リクエスト失敗 |
| `PermissionDenied` | 通知許可が拒否された |
| `InitializationFailed` | NotificationCenter初期化失敗 |
| `SendFailed` | 通知送信失敗 |
| `UnsignedBinary` | 署名なしバイナリでの実行 |
| `InvalidInput` | 入力値バリデーションエラー |

## Testing
- ✅ `cargo build` - Success
- ✅ `cargo test --lib` - 147 tests passed (22 new notification tests)
- ✅ `cargo clippy -- -D warnings` - No warnings
- ✅ `cargo fmt --check` - Formatted correctly

Closes #23