### PR TITLE
feat: LaunchAgentインストーラー + サービス状態確認機能を実装

### DIFF
--- a/src/launchagent/installer.rs
+++ b/src/launchagent/installer.rs
@@ -1,0 +1,294 @@
+//! LaunchAgentインストール・アンインストールロジック
+//!
+//! LaunchAgentのインストールおよびアンインストール処理を提供する。
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+use super::error::{LaunchAgentError, Result};
+use super::launchctl;
+use super::plist::PomodoroLaunchAgent;
+use super::{get_launch_agents_dir, get_log_dir, get_plist_path};
+
+/// pomodoroバイナリの絶対パスを解決する
+///
+/// `which pomodoro` コマンドを実行してバイナリのパスを取得する。
+///
+/// # Returns
+/// バイナリの絶対パス
+///
+/// # Errors
+/// - whichコマンドの実行に失敗
+/// - バイナリが見つからない
+///
+/// # Example
+/// ```rust,ignore
+/// let binary_path = resolve_binary_path()?;
+/// assert!(binary_path.starts_with("/"));
+/// ```
+pub fn resolve_binary_path() -> Result<String> {
+    let output = Command::new("which")
+        .arg("pomodoro")
+        .output()
+        .map_err(|e| {
+            LaunchAgentError::BinaryPathResolution(format!(
+                "Failed to execute 'which pomodoro': {}",
+                e
+            ))
+        })?;
+
+    if !output.status.success() {
+        return Err(LaunchAgentError::BinaryPathResolution(
+            "pomodoro binary not found in PATH".to_string(),
+        ));
+    }
+
+    let path = String::from_utf8(output.stdout)
+        .map_err(|e| {
+            LaunchAgentError::BinaryPathResolution(format!("Failed to parse which output: {}", e))
+        })?
+        .trim()
+        .to_string();
+
+    if path.is_empty() {
+        return Err(LaunchAgentError::BinaryPathResolution(
+            "pomodoro binary path is empty".to_string(),
+        ));
+    }
+
+    tracing::debug!("Resolved pomodoro binary path: {}", path);
+    Ok(path)
+}
+
+/// LaunchAgentをインストールする
+///
+/// 以下の処理を順番に実行する:
+/// 1. バイナリパスを解決（`which pomodoro`）
+/// 2. ログディレクトリを作成（`~/.pomodoro/logs/`）
+/// 3. Plistを生成（`PomodoroLaunchAgent::new`）
+/// 4. plistファイルを書き込み（`~/Library/LaunchAgents/`）
+/// 5. パーミッションを設定（0644）
+/// 6. 既存サービスをアンロード（冪等性確保）
+/// 7. サービスをロード
+///
+/// # Returns
+/// インストール成功時はOk、失敗時はErr
+///
+/// # Errors
+/// - バイナリパスの解決に失敗
+/// - ホームディレクトリの取得に失敗
+/// - ログディレクトリの作成に失敗
+/// - plistファイルの書き込みに失敗
+/// - launchctl loadに失敗
+///
+/// # Example
+/// ```rust,ignore
+/// use pomodoro::launchagent::installer;
+///
+/// installer::install()?;
+/// println!("LaunchAgent installed successfully");
+/// ```
+pub fn install() -> Result<()> {
+    // 1. バイナリパスを解決
+    let binary_path = resolve_binary_path()?;
+
+    // 2. ログディレクトリを作成
+    let log_dir = get_log_dir()?;
+    fs::create_dir_all(&log_dir).map_err(LaunchAgentError::LogDirectoryCreation)?;
+    tracing::debug!("Created log directory: {:?}", log_dir);
+
+    // 3. Plist生成
+    let plist = PomodoroLaunchAgent::new(&binary_path, log_dir.to_string_lossy().to_string());
+    let plist_xml = plist.to_xml()?;
+
+    // 4. LaunchAgentsディレクトリを作成（存在しない場合）
+    let launch_agents_dir = get_launch_agents_dir()?;
+    fs::create_dir_all(&launch_agents_dir).map_err(|e| {
+        LaunchAgentError::PlistWrite(format!("Failed to create LaunchAgents directory: {}", e))
+    })?;
+
+    // 5. plistファイルを書き込み
+    let plist_path = get_plist_path()?;
+    fs::write(&plist_path, &plist_xml)
+        .map_err(|e| LaunchAgentError::PlistWrite(format!("Failed to write plist file: {}", e)))?;
+    tracing::debug!("Wrote plist file: {:?}", plist_path);
+
+    // 6. パーミッション設定（0644: rw-r--r--）
+    let mut perms = fs::metadata(&plist_path)
+        .map_err(|e| LaunchAgentError::PlistWrite(format!("Failed to get plist metadata: {}", e)))?
+        .permissions();
+    perms.set_mode(0o644);
+    fs::set_permissions(&plist_path, perms).map_err(|e| {
+        LaunchAgentError::PlistWrite(format!("Failed to set plist permissions: {}", e))
+    })?;
+
+    // 7. 既存のサービスをアンロード（冪等性確保、エラーは無視）
+    let _ = launchctl::unload(&plist_path);
+
+    // 8. サービスをロード
+    launchctl::load(&plist_path)?;
+
+    tracing::info!("LaunchAgent installed successfully at {:?}", plist_path);
+    Ok(())
+}
+
+/// LaunchAgentをアンインストールする
+///
+/// 以下の処理を順番に実行する:
+/// 1. plistファイルの存在確認（存在しない場合は成功として扱う）
+/// 2. サービスをアンロード（エラーは無視）
+/// 3. plistファイルを削除
+///
+/// # Returns
+/// アンインストール成功時はOk、失敗時はErr
+///
+/// # Errors
+/// - ホームディレクトリの取得に失敗
+/// - plistファイルの削除に失敗
+///
+/// # Note
+/// plistファイルが存在しない場合は、既にアンインストール済みとして
+/// 成功（Ok）を返す（冪等性確保）。
+///
+/// # Example
+/// ```rust,ignore
+/// use pomodoro::launchagent::installer;
+///
+/// installer::uninstall()?;
+/// println!("LaunchAgent uninstalled successfully");
+/// ```
+pub fn uninstall() -> Result<()> {
+    // 1. plistファイルパスを取得
+    let plist_path = get_plist_path()?;
+
+    // 2. plistファイルが存在しない場合は成功として扱う
+    if !plist_path.exists() {
+        tracing::info!("LaunchAgent plist file does not exist, nothing to uninstall");
+        return Ok(());
+    }
+
+    // 3. サービスをアンロード（エラーは無視）
+    let _ = launchctl::unload(&plist_path);
+
+    // 4. plistファイルを削除
+    fs::remove_file(&plist_path).map_err(|e| {
+        LaunchAgentError::PlistRemove(format!("Failed to remove plist file: {}", e))
+    })?;
+
+    tracing::info!("LaunchAgent uninstalled successfully");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_binary_path_returns_error_when_not_found() {
+        // This test assumes 'pomodoro' is not in PATH during testing
+        // The result depends on the environment, so we just verify the function doesn't panic
+        let result = resolve_binary_path();
+        // Either succeeds (if pomodoro is in PATH) or returns proper error
+        match result {
+            Ok(path) => assert!(!path.is_empty()),
+            Err(e) => assert!(matches!(e, LaunchAgentError::BinaryPathResolution(_))),
+        }
+    }
+
+    #[test]
+    fn test_resolve_binary_path_which_command_works() {
+        // Test that 'which' command itself works (using a common command)
+        let output = Command::new("which").arg("ls").output();
+
+        assert!(output.is_ok());
+        let output = output.unwrap();
+        // 'ls' should always be found on Unix systems
+        assert!(output.status.success());
+    }
+
+    #[test]
+    #[ignore = "Modifies system state; run manually on macOS"]
+    fn test_install_and_uninstall_integration() {
+        // This is an integration test that modifies the system
+        // Run manually: cargo test test_install_and_uninstall_integration -- --ignored
+
+        // Install
+        let install_result = install();
+        assert!(
+            install_result.is_ok(),
+            "Install failed: {:?}",
+            install_result
+        );
+
+        // Verify plist file exists
+        let plist_path = get_plist_path().unwrap();
+        assert!(plist_path.exists(), "Plist file should exist after install");
+
+        // Uninstall
+        let uninstall_result = uninstall();
+        assert!(
+            uninstall_result.is_ok(),
+            "Uninstall failed: {:?}",
+            uninstall_result
+        );
+
+        // Verify plist file is removed
+        assert!(
+            !plist_path.exists(),
+            "Plist file should not exist after uninstall"
+        );
+    }
+
+    #[test]
+    fn test_uninstall_when_not_installed() {
+        // Uninstalling when not installed should succeed (idempotency)
+        // This test assumes the LaunchAgent is not actually installed
+        // We can't fully test this without modifying the system, but we can test the logic
+
+        // Create a mock scenario: if plist doesn't exist, uninstall should succeed
+        let result = get_plist_path();
+        if let Ok(path) = result {
+            if !path.exists() {
+                // If plist doesn't exist, uninstall should succeed
+                let uninstall_result = uninstall();
+                assert!(
+                    uninstall_result.is_ok(),
+                    "Uninstall should succeed when not installed"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_log_dir_creation() {
+        // Test that log dir path can be obtained
+        let result = get_log_dir();
+        if let Ok(log_dir) = result {
+            assert!(log_dir.to_string_lossy().contains(".pomodoro/logs"));
+        }
+    }
+
+    #[test]
+    fn test_plist_path() {
+        // Test that plist path can be obtained
+        let result = get_plist_path();
+        if let Ok(plist_path) = result {
+            assert!(plist_path
+                .to_string_lossy()
+                .contains("Library/LaunchAgents"));
+            assert!(plist_path
+                .to_string_lossy()
+                .contains("com.github.takemo101.pomodoro.plist"));
+        }
+    }
+
+    #[test]
+    fn test_launch_agents_dir() {
+        // Test that LaunchAgents dir path can be obtained
+        let result = get_launch_agents_dir();
+        if let Ok(dir) = result {
+            assert!(dir.to_string_lossy().contains("Library/LaunchAgents"));
+        }
+    }
+}

--- a/src/launchagent/mod.rs
+++ b/src/launchagent/mod.rs
@@ -8,36 +8,42 @@
 //! - `error` - エラー型定義
 //! - `plist` - Plist構造体定義、XML生成
 //! - `launchctl` - launchctlコマンド実行ラッパー
+//! - `installer` - インストール・アンインストールロジック
+//! - `status` - サービス状態確認
 //!
 //! # 例
 //!
 //! ```rust,ignore
-//! use pomodoro::launchagent::{PomodoroLaunchAgent, launchctl};
+//! use pomodoro::launchagent::{install, uninstall, is_running, get_status};
 //!
-//! // Plist生成
-//! let plist = PomodoroLaunchAgent::new(
-//!     "/usr/local/bin/pomodoro",
-//!     "/Users/username/.pomodoro/logs",
-//! );
-//! let xml = plist.to_xml()?;
+//! // LaunchAgentをインストール
+//! install()?;
 //!
-//! // サービス登録（macOSのみ）
-//! launchctl::load(&plist_path)?;
+//! // サービス状態を確認
+//! if is_running()? {
+//!     let status = get_status()?;
+//!     println!("PID: {:?}", status.pid);
+//! }
+//!
+//! // LaunchAgentをアンインストール
+//! uninstall()?;
 //! ```
 //!
 //! # 注意事項
 //!
 //! - すべてのパスは絶対パスで指定する必要がある（`~`は使用不可）
 //! - launchctl関連の関数はmacOSでのみ正常に動作する
-//! - install/uninstall関数は次のSubtask (#35) で実装予定
 
 pub mod error;
+pub mod installer;
 pub mod launchctl;
 pub mod plist;
+pub mod status;
 
-// Re-export common types
 pub use error::{LaunchAgentError, Result};
+pub use installer::{install, resolve_binary_path, uninstall};
 pub use plist::{PomodoroLaunchAgent, DEFAULT_LABEL};
+pub use status::{get_status, is_running, ServiceStatus};
 
 /// plistファイルのデフォルトパスを取得
 ///
@@ -73,33 +79,6 @@ pub fn get_log_dir() -> Result<std::path::PathBuf> {
 pub fn get_launch_agents_dir() -> Result<std::path::PathBuf> {
     let home_dir = dirs::home_dir().ok_or(LaunchAgentError::HomeDirectoryNotFound)?;
     Ok(home_dir.join("Library/LaunchAgents"))
-}
-
-// Stub functions for install/uninstall (to be implemented in Subtask #35)
-// These are placeholder signatures that will be fully implemented later.
-
-/// LaunchAgentをインストールする（スタブ - #35で実装予定）
-///
-/// # Returns
-/// インストール成功時はOk、失敗時はErr
-///
-/// # Note
-/// この関数は現在スタブであり、完全な実装はSubtask #35で行われる。
-#[allow(dead_code)]
-pub fn install() -> Result<()> {
-    unimplemented!("install() will be implemented in Subtask #35")
-}
-
-/// LaunchAgentをアンインストールする（スタブ - #35で実装予定）
-///
-/// # Returns
-/// アンインストール成功時はOk、失敗時はErr
-///
-/// # Note
-/// この関数は現在スタブであり、完全な実装はSubtask #35で行われる。
-#[allow(dead_code)]
-pub fn uninstall() -> Result<()> {
-    unimplemented!("uninstall() will be implemented in Subtask #35")
 }
 
 /// LaunchAgentがインストールされているか確認する

--- a/src/launchagent/status.rs
+++ b/src/launchagent/status.rs
@@ -1,0 +1,179 @@
+//! サービス状態確認モジュール
+//!
+//! LaunchAgentサービスの実行状態を確認する機能を提供する。
+
+use super::error::{LaunchAgentError, Result};
+use super::launchctl;
+use super::plist::DEFAULT_LABEL;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ServiceStatus {
+    pub running: bool,
+    pub pid: Option<u32>,
+    pub status_code: Option<i32>,
+}
+
+impl ServiceStatus {
+    pub fn not_running() -> Self {
+        Self::default()
+    }
+
+    pub fn running_with_pid(pid: u32) -> Self {
+        Self {
+            running: true,
+            pid: Some(pid),
+            status_code: Some(0),
+        }
+    }
+}
+
+pub fn is_running() -> Result<bool> {
+    match launchctl::list(DEFAULT_LABEL) {
+        Ok(_) => Ok(true),
+        Err(LaunchAgentError::LaunchctlExecution(msg)) if msg.contains("not found") => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn get_status() -> Result<ServiceStatus> {
+    match launchctl::list(DEFAULT_LABEL) {
+        Ok(output) => Ok(parse_launchctl_output(&output)),
+        Err(LaunchAgentError::LaunchctlExecution(msg)) if msg.contains("not found") => {
+            Ok(ServiceStatus::not_running())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn parse_launchctl_output(output: &str) -> ServiceStatus {
+    let pid = extract_field(output, "PID").and_then(|s| s.parse::<u32>().ok());
+    let status_code = extract_field(output, "LastExitStatus").and_then(|s| s.parse::<i32>().ok());
+
+    ServiceStatus {
+        running: pid.is_some(),
+        pid,
+        status_code,
+    }
+}
+
+fn extract_field<'a>(output: &'a str, field: &str) -> Option<&'a str> {
+    let pattern = format!("\"{}\" = ", field);
+    output
+        .lines()
+        .find(|line| line.contains(&pattern))
+        .and_then(|line| {
+            line.split('=')
+                .nth(1)
+                .map(|s| s.trim().trim_end_matches(';').trim_matches('"'))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_status_default() {
+        let status = ServiceStatus::default();
+        assert!(!status.running);
+        assert!(status.pid.is_none());
+        assert!(status.status_code.is_none());
+    }
+
+    #[test]
+    fn test_service_status_not_running() {
+        let status = ServiceStatus::not_running();
+        assert!(!status.running);
+        assert!(status.pid.is_none());
+        assert!(status.status_code.is_none());
+    }
+
+    #[test]
+    fn test_service_status_running_with_pid() {
+        let status = ServiceStatus::running_with_pid(12345);
+        assert!(status.running);
+        assert_eq!(status.pid, Some(12345));
+        assert_eq!(status.status_code, Some(0));
+    }
+
+    #[test]
+    fn test_parse_launchctl_output_with_pid() {
+        let output = r#"{
+    "Label" = "com.github.takemo101.pomodoro";
+    "LimitLoadToSessionType" = "Aqua";
+    "OnDemand" = false;
+    "LastExitStatus" = 0;
+    "PID" = 12345;
+    "Program" = "/usr/local/bin/pomodoro";
+};"#;
+
+        let status = parse_launchctl_output(output);
+        assert!(status.running);
+        assert_eq!(status.pid, Some(12345));
+        assert_eq!(status.status_code, Some(0));
+    }
+
+    #[test]
+    fn test_parse_launchctl_output_without_pid() {
+        let output = r#"{
+    "Label" = "com.github.takemo101.pomodoro";
+    "LastExitStatus" = 1;
+};"#;
+
+        let status = parse_launchctl_output(output);
+        assert!(!status.running);
+        assert!(status.pid.is_none());
+        assert_eq!(status.status_code, Some(1));
+    }
+
+    #[test]
+    fn test_parse_launchctl_output_empty() {
+        let status = parse_launchctl_output("");
+        assert!(!status.running);
+        assert!(status.pid.is_none());
+        assert!(status.status_code.is_none());
+    }
+
+    #[test]
+    fn test_extract_field_pid() {
+        let output = r#"    "PID" = 12345;"#;
+        assert_eq!(extract_field(output, "PID"), Some("12345"));
+    }
+
+    #[test]
+    fn test_extract_field_last_exit_status() {
+        let output = r#"    "LastExitStatus" = 0;"#;
+        assert_eq!(extract_field(output, "LastExitStatus"), Some("0"));
+    }
+
+    #[test]
+    fn test_extract_field_not_found() {
+        let output = r#"    "Label" = "test";"#;
+        assert_eq!(extract_field(output, "PID"), None);
+    }
+
+    #[test]
+    fn test_extract_field_string_value() {
+        let output = r#"    "Label" = "com.github.takemo101.pomodoro";"#;
+        assert_eq!(
+            extract_field(output, "Label"),
+            Some("com.github.takemo101.pomodoro")
+        );
+    }
+
+    #[test]
+    #[ignore = "Requires launchctl; run manually on macOS"]
+    fn test_is_running_when_not_installed() {
+        let result = is_running();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[ignore = "Requires launchctl; run manually on macOS"]
+    fn test_get_status_when_not_installed() {
+        let result = get_status();
+        assert!(result.is_ok());
+        let status = result.unwrap();
+        assert!(!status.running);
+    }
+}


### PR DESCRIPTION
## Summary

Issue #35 の実装: LaunchAgentのインストール・アンインストールロジックとサービス状態確認機能を実装。

## Changes

### 新規ファイル
- `src/launchagent/installer.rs` (~180行)
  - `install()` - LaunchAgentインストール（バイナリパス解決、Plist生成、権限設定、launchctl load）
  - `uninstall()` - LaunchAgentアンインストール（launchctl unload、ファイル削除）
  - `resolve_binary_path()` - `which pomodoro`でバイナリパス解決

- `src/launchagent/status.rs` (~80行)
  - `ServiceStatus` - サービス状態を表す構造体（running, pid, status_code）
  - `is_running()` - サービス実行中かチェック
  - `get_status()` - 詳細状態を取得
  - `parse_launchctl_output()` - launchctl list出力のパース

### 更新ファイル
- `src/launchagent/mod.rs`
  - 新モジュール（installer, status）のエクスポート追加
  - スタブ関数（install, uninstall）を削除
  - 公開API完成: install(), uninstall(), is_running(), get_status(), ServiceStatus

## Testing

- 240テスト通過（12 ignored - 環境依存）
- clippy警告なし
- cargo fmt適用済み

## Related

- Closes #35
- Parent Epic: #11 (LaunchAgent管理)
- Depends on: PR #53 (Plist + launchctl - merged)