### PR TITLE
ci: リリースワークフロー構築とv0.1.0リリース準備

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,194 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-release:
+    name: Build Release (${{ matrix.target }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Strip binary
+        run: strip target/${{ matrix.target }}/release/pomodoro
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pomodoro-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/pomodoro
+
+  create-universal-binary:
+    name: Create Universal Binary
+    runs-on: macos-latest
+    needs: build-release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download x86_64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pomodoro-x86_64-apple-darwin
+          path: ./artifacts/x86_64
+
+      - name: Download aarch64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pomodoro-aarch64-apple-darwin
+          path: ./artifacts/aarch64
+
+      - name: Create universal binary
+        run: |
+          lipo -create \
+            ./artifacts/x86_64/pomodoro \
+            ./artifacts/aarch64/pomodoro \
+            -output ./pomodoro-universal
+
+      - name: Verify universal binary
+        run: |
+          lipo -info ./pomodoro-universal
+          file ./pomodoro-universal
+
+      - name: Code sign binary (optional)
+        if: ${{ env.MACOS_CERTIFICATE != '' }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # キーチェーン作成
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+
+          # 証明書インポート
+          echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+
+          # 証明書の信頼設定
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          # コード署名
+          IDENTITY=$(security find-identity -v -p codesigning build.keychain | head -1 | grep -o '".*"' | tr -d '"')
+          codesign --force --sign "$IDENTITY" \
+            --options runtime \
+            --timestamp \
+            ./pomodoro-universal
+
+          # 署名検証
+          codesign --verify --verbose ./pomodoro-universal
+
+      - name: Ad-hoc sign if no certificate
+        if: ${{ env.MACOS_CERTIFICATE == '' }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        run: |
+          codesign --force --sign - ./pomodoro-universal
+          codesign --verify --verbose ./pomodoro-universal
+
+      - name: Create tarball
+        run: |
+          tar -czf pomodoro-universal-macos.tar.gz pomodoro-universal
+          shasum -a 256 pomodoro-universal-macos.tar.gz > pomodoro-universal-macos.tar.gz.sha256
+
+      - name: Upload universal binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: pomodoro-universal
+          path: |
+            pomodoro-universal-macos.tar.gz
+            pomodoro-universal-macos.tar.gz.sha256
+
+  create-github-release:
+    name: Create GitHub Release
+    runs-on: macos-latest
+    needs: create-universal-binary
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download universal binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pomodoro-universal
+          path: ./release
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release v${{ steps.version.outputs.version }}
+          body: |
+            ## ポモドーロタイマーCLI v${{ steps.version.outputs.version }}
+
+            ### インストール方法
+
+            #### 手動インストール
+            ```bash
+            # ダウンロード
+            curl -LO https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/pomodoro-universal-macos.tar.gz
+
+            # SHA256チェックサム検証
+            curl -LO https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/pomodoro-universal-macos.tar.gz.sha256
+            shasum -a 256 -c pomodoro-universal-macos.tar.gz.sha256
+
+            # 解凍
+            tar -xzf pomodoro-universal-macos.tar.gz
+
+            # インストール
+            sudo mv pomodoro-universal /usr/local/bin/pomodoro
+            sudo chmod +x /usr/local/bin/pomodoro
+            ```
+
+            ### 動作確認
+            ```bash
+            pomodoro --version
+            ```
+
+            ### 変更内容
+            - 詳細は [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md) を参照
+
+            ### システム要件
+            - macOS 12 (Monterey) 以降
+            - Intel Mac または Apple Silicon Mac
+          files: |
+            ./release/pomodoro-universal-macos.tar.gz
+            ./release/pomodoro-universal-macos.tar.gz.sha256
+          draft: false
+          prerelease: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+.PHONY: help install build build-release test lint clean run install-local uninstall-local
+
+help: ## ヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## 依存関係をインストール
+	rustup target add x86_64-apple-darwin aarch64-apple-darwin
+
+build: ## デバッグビルド
+	cargo build
+
+build-release: ## リリースビルド（ユニバーサルバイナリ）
+	cargo build --release --target x86_64-apple-darwin
+	cargo build --release --target aarch64-apple-darwin
+	mkdir -p target/release
+	lipo -create \
+		target/x86_64-apple-darwin/release/pomodoro \
+		target/aarch64-apple-darwin/release/pomodoro \
+		-output target/release/pomodoro-universal
+
+test: ## テスト実行
+	cargo test --all-features
+
+lint: ## Lint実行
+	cargo fmt --all -- --check
+	cargo clippy --all-targets --all-features -- -D warnings
+
+clean: ## ビルド成果物削除
+	cargo clean
+
+run: ## デーモン起動
+	cargo run -- daemon
+
+install-local: build-release ## ローカルにインストール
+	sudo cp target/release/pomodoro-universal /usr/local/bin/pomodoro
+	sudo chmod +x /usr/local/bin/pomodoro
+
+uninstall-local: ## ローカルからアンインストール
+	sudo rm -f /usr/local/bin/pomodoro


### PR DESCRIPTION
## 概要
Closes #16

本番リリースに向けたCI/CD設定（GitHub Actions）と開発補助ツール（Makefile）を追加しました。
これにより、タグをプッシュするだけで自動的にマルチアーキテクチャ（Intel/Apple Silicon）のバイナリがビルドされ、GitHub Releasesに公開されるようになります。

## 変更内容

### 🚀 リリースワークフロー (`.github/workflows/release.yml`)
- トリガー: `v*.*.*` タグのプッシュ
- ジョブ構成:
  - **build-release**: macOS-latestで `x86_64` と `aarch64` 向けにリリースビルドを実行
  - **create-universal-binary**: `lipo` コマンドでユニバーサルバイナリを作成
  - **code-sign**: 証明書（Secrets）がある場合はコード署名、なければAd-hoc署名を実施
  - **create-github-release**: GitHub Releasesを作成し、バイナリ（tar.gz）とチェックサムをアップロード

### 🛠️ 開発補助 (`Makefile`)
以下のコマンドを追加し、開発効率を向上させました：
- `make build`: デバッグビルド
- `make build-release`: リリースビルド（ユニバーサルバイナリ作成）
- `make test`: テスト実行
- `make lint`: フォーマットとClippyチェック
- `make install-local`: `/usr/local/bin` へのローカルインストール
- `make help`: コマンド一覧表示

### ⚙️ その他
- `Cargo.toml` の `profile.release` 設定を確認（LTO有効化、ストリップ、サイズ最適化）

## テスト結果
- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --all-features` 通過

## 今後の手順
このPRがマージされた後、以下の手順でv0.1.0をリリースします：
1. `git tag -a v0.1.0 -m "Initial release"`
2. `git push origin v0.1.0`
3. GitHub Actionsのリリースワークフローが自動実行されるのを確認