### PR TITLE
fix: CLIコマンド(install, uninstall, daemon)の実装漏れを修正

### DIFF
--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -14,6 +14,11 @@ impl Display {
         Self
     }
 
+    /// Show success message
+    pub fn show_success(&self, msg: &str) {
+        println!("{} {}", "✓".green().bold(), msg.green());
+    }
+
     /// Show start success message
     pub fn show_start_success(&self, response: IpcResponse) {
         println!("{} {}", "✓".green().bold(), response.message.green());

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,17 +74,113 @@ async fn main() -> Result<()> {
                 display.show_error(&format!("Failed to get status: {}", e));
             }
         },
-        Commands::Install => {
-            // TODO: Implement LaunchAgent installation
-            display.show_error("Install command not yet implemented");
-        }
-        Commands::Uninstall => {
-            // TODO: Implement LaunchAgent uninstallation
-            display.show_error("Uninstall command not yet implemented");
-        }
+        Commands::Install => match pomodoro::launchagent::install() {
+            Ok(_) => display.show_success("LaunchAgent installed successfully"),
+            Err(e) => display.show_error(&format!("Failed to install LaunchAgent: {}", e)),
+        },
+        Commands::Uninstall => match pomodoro::launchagent::uninstall() {
+            Ok(_) => display.show_success("LaunchAgent uninstalled successfully"),
+            Err(e) => display.show_error(&format!("Failed to uninstall LaunchAgent: {}", e)),
+        },
         Commands::Daemon => {
-            // TODO: Implement daemon mode
-            display.show_error("Daemon mode not yet implemented");
+            // デーモン設定の初期化
+            let config = pomodoro::types::PomodoroConfig::default();
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+            // TimerEngineの初期化
+            let engine = std::sync::Arc::new(tokio::sync::Mutex::new(
+                pomodoro::daemon::TimerEngine::new(config, tx),
+            ));
+
+            // IPCサーバーの初期化
+            let socket_path = get_socket_path();
+            let server = pomodoro::daemon::IpcServer::new(&socket_path)
+                .map_err(|e| anyhow::anyhow!("Failed to create IPC server: {}", e))?;
+
+            println!("Daemon started at {:?}", socket_path);
+
+            // NotificationManagerの初期化 (macOSのみ)
+            #[cfg(target_os = "macos")]
+            let notification_manager = {
+                // メインスレッドマーカーの取得
+                let mtm = objc2::MainThreadMarker::new()
+                    .expect("Daemon must run on the main thread for UI/Notification operations");
+
+                match pomodoro::notification::NotificationManager::new(mtm) {
+                    Ok(nm) => Some(nm),
+                    Err(e) => {
+                        eprintln!("Failed to initialize NotificationManager: {}", e);
+                        None
+                    }
+                }
+            };
+
+            // SoundPlayerの初期化
+            let sound_player = pomodoro::sound::create_sound_player(false);
+
+            // メインループ
+            loop {
+                tokio::select! {
+                    // IPCリクエスト処理
+                    result = server.accept() => {
+                        match result {
+                            Ok(mut stream) => {
+                                let engine = engine.clone();
+                                tokio::spawn(async move {
+                                    match pomodoro::daemon::IpcServer::receive_request(&mut stream).await {
+                                        Ok(request) => {
+                                            let response = pomodoro::daemon::handle_request(request, engine).await;
+                                            if let Err(e) = pomodoro::daemon::IpcServer::send_response(&mut stream, &response).await {
+                                                eprintln!("Failed to send response: {}", e);
+                                            }
+                                        }
+                                        Err(e) => {
+                                            eprintln!("Failed to receive request: {}", e);
+                                        }
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                eprintln!("Failed to accept connection: {}", e);
+                                // 致命的なエラーでなければ続行
+                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                            }
+                        }
+                    }
+
+                    // タイマーイベント処理
+                    Some(event) = rx.recv() => {
+                        println!("Event received: {:?}", event);
+                        match event {
+                            pomodoro::daemon::TimerEvent::WorkCompleted { .. } => {
+                                #[cfg(target_os = "macos")]
+                                if let Some(nm) = &notification_manager {
+                                    if let Err(e) = nm.send_work_complete_notification(Some("作業完了")) {
+                                        eprintln!("Failed to send notification: {}", e);
+                                    }
+                                }
+
+                                if let Err(e) = sound_player.play(&pomodoro::sound::SoundSource::Embedded { name: "default".to_string() }).await {
+                                    eprintln!("Failed to play sound: {}", e);
+                                }
+                            }
+                            pomodoro::daemon::TimerEvent::BreakCompleted { .. } => {
+                                #[cfg(target_os = "macos")]
+                                if let Some(nm) = &notification_manager {
+                                    if let Err(e) = nm.send_break_complete_notification(None) {
+                                        eprintln!("Failed to send notification: {}", e);
+                                    }
+                                }
+
+                                if let Err(e) = sound_player.play(&pomodoro::sound::SoundSource::Embedded { name: "default".to_string() }).await {
+                                    eprintln!("Failed to play sound: {}", e);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
         }
         Commands::Completions { shell } => {
             generate_completions(shell);
@@ -92,4 +188,15 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// ソケットパスを取得
+fn get_socket_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+
+    std::path::PathBuf::from(home)
+        .join(".pomodoro")
+        .join("pomodoro.sock")
 }


### PR DESCRIPTION
## 概要
CLIの `daemon`, `install`, `uninstall` コマンドの中身が実装されていなかったため、修正しました。
これにより、`pomodoro start` 実行時に "Failed to connect to daemon" エラーが発生する問題が解決します。

## 修正内容
- `src/main.rs`:
  - `Commands::Daemon`: IPCサーバーの起動、タイマーエンジンの初期化、イベントループの実装を追加。
  - `Commands::Install`: `pomodoro::launchagent::install()` を呼び出すように修正。
  - `Commands::Uninstall`: `pomodoro::launchagent::uninstall()` を呼び出すように修正。
  - `get_socket_path` ヘルパー関数の追加。
- `src/cli/display.rs`:
  - `show_success` メソッドを追加（成功メッセージ表示用）。

## 影響範囲
- デーモンモードの起動
- LaunchAgentのインストール/アンインストール

## 検証
- `cargo check` でコンパイルエラーがないことを確認。