### PR TITLE
fix: バンドルコンテキストなしでの通知センターアクセス時のクラッシュを防止

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "0.6"
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSSet", "NSArray", "NSObject"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSSet", "NSArray", "NSObject", "NSBundle"] }
 objc2-user-notifications = "0.3"
 
 [dev-dependencies]

--- a/src/notification/error.rs
+++ b/src/notification/error.rs
@@ -10,6 +10,8 @@ pub enum NotificationError {
     UnsignedBinary,
     InitializationFailed(String),
     InvalidInput(String),
+    /// アプリバンドルコンテキストがない（CLI直接実行時）
+    NoBundleContext,
 }
 
 impl fmt::Display for NotificationError {
@@ -35,6 +37,12 @@ impl fmt::Display for NotificationError {
             }
             NotificationError::InvalidInput(msg) => {
                 write!(f, "無効な入力: {}", msg)
+            }
+            NotificationError::NoBundleContext => {
+                write!(
+                    f,
+                    "アプリバンドルコンテキストがありません。通知機能は無効です"
+                )
             }
         }
     }

--- a/src/notification/manager.rs
+++ b/src/notification/manager.rs
@@ -30,7 +30,7 @@ pub struct NotificationManager {
 
 impl NotificationManager {
     pub fn new(mtm: MainThreadMarker) -> Result<Self, NotificationError> {
-        let center = NotificationCenter::shared();
+        let center = NotificationCenter::try_shared()?;
 
         let (auth_tx, auth_rx) = channel();
         center.request_authorization(auth_tx);


### PR DESCRIPTION
## Summary
- CLIバイナリ直接実行時の`UNUserNotificationCenter`クラッシュを修正
- バンドルID事前チェックにより、通知機能は無効化されるがデーモンは正常起動

## 問題
`pomodoro daemon`実行時に以下のエラーでクラッシュ:
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', 
reason: 'bundleProxyForCurrentProcess is nil: mainBundle.bundleURL file:///usr/local/bin/'
```

## 原因
`UNUserNotificationCenter::currentNotificationCenter()`は有効なアプリバンドルコンテキストを必要とする。
`/usr/local/bin/`にインストールされたCLIバイナリにはバンドルIDがないため、Objective-C例外がスローされる。

## 解決策
`NSBundle::mainBundle().bundleIdentifier()`でバンドルIDの存在を事前チェック。
バンドルIDがない場合は`NoBundleContext`エラーを返し、通知機能を無効化する。

## Changes
- `Cargo.toml`: `NSBundle` feature追加
- `src/notification/error.rs`: `NoBundleContext` エラーvariant追加
- `src/notification/center.rs`: `shared()` → `try_shared()` に変更、バンドルチェック追加
- `src/notification/manager.rs`: `try_shared()?` を使用

## Testing
- [x] `cargo build` passed
- [x] `cargo test` passed (240 passed, 16 ignored)
- [x] `cargo clippy` passed