### PR TITLE
fix: Issue #64 pomodoro start options ignored

### DIFF
--- a/src/daemon/ipc.rs
+++ b/src/daemon/ipc.rs
@@ -176,7 +176,7 @@ pub async fn handle_request(request: IpcRequest, engine: Arc<Mutex<TimerEngine>>
 
 /// startコマンドを処理
 fn handle_start(engine: &mut TimerEngine, params: StartParams) -> IpcResponse {
-    match engine.start(params.task_name.clone()) {
+    match engine.start(Some(params)) {
         Ok(()) => {
             let state = engine.get_state();
             IpcResponse::success(

--- a/tests/e2e/performance.rs
+++ b/tests/e2e/performance.rs
@@ -81,7 +81,7 @@ async fn test_performance_event_processing_latency() {
 
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("パフォーマンステスト".to_string())).unwrap();
+        eng.start(Some(pomodoro::types::StartParams { task_name: Some("パフォーマンステスト".to_string()), ..Default::default() })).unwrap();
     }
 
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/tests/e2e/scenarios.rs
+++ b/tests/e2e/scenarios.rs
@@ -116,7 +116,7 @@ async fn test_e2e_pause_resume_flow() {
 
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("一時停止テスト".to_string())).unwrap();
+        eng.start(Some(pomodoro::types::StartParams { task_name: Some("一時停止テスト".to_string()), ..Default::default() })).unwrap();
     }
 
     for _ in 0..10 {
@@ -173,7 +173,7 @@ async fn test_e2e_stop_flow() {
 
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("停止テスト".to_string())).unwrap();
+        eng.start(Some(pomodoro::types::StartParams { task_name: Some("停止テスト".to_string()), ..Default::default() })).unwrap();
     }
 
     for _ in 0..10 {
@@ -209,7 +209,7 @@ async fn test_e2e_auto_cycle() {
 
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("自動サイクルテスト".to_string())).unwrap();
+        eng.start(Some(pomodoro::types::StartParams { task_name: Some("自動サイクルテスト".to_string()), ..Default::default() })).unwrap();
     }
 
     loop {
@@ -261,7 +261,7 @@ async fn test_e2e_long_break_after_four_pomodoros() {
 
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("4ポモドーロテスト".to_string())).unwrap();
+        eng.start(Some(pomodoro::types::StartParams { task_name: Some("4ポモドーロテスト".to_string()), ..Default::default() })).unwrap();
     }
 
     for i in 1..=4 {
@@ -339,7 +339,7 @@ async fn test_e2e_focus_mode_integration() {
 
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("フォーカスモードテスト".to_string()))
+        eng.start(Some(pomodoro::types::StartParams { task_name: Some("フォーカスモードテスト".to_string()), ..Default::default() }))
             .unwrap();
     }
 

--- a/tests/integration/daemon_cli.rs
+++ b/tests/integration/daemon_cli.rs
@@ -82,7 +82,7 @@ async fn test_ipc_pause_timer() {
     // 事前にタイマーを開始
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("タスク".to_string())).unwrap();
+        eng.start(Some(StartParams { task_name: Some("タスク".to_string()), ..Default::default() })).unwrap();
     }
 
     // クライアント: pauseリクエスト
@@ -132,7 +132,7 @@ async fn test_ipc_status() {
     // タイマー開始
     {
         let mut eng = engine.lock().await;
-        eng.start(Some("ステータス確認タスク".to_string())).unwrap();
+        eng.start(Some(StartParams { task_name: Some("ステータス確認タスク".to_string()), ..Default::default() })).unwrap();
     }
 
     // クライアント: statusリクエスト

--- a/tests/integration/timer_notification.rs
+++ b/tests/integration/timer_notification.rs
@@ -155,7 +155,7 @@ async fn tc_i_005_work_started_event_triggers_notification() {
     let (mut engine, mut rx) = create_test_engine();
     let notification_sender = Arc::new(MockNotificationSender::new());
 
-    engine.start(Some("通知テスト".to_string())).unwrap();
+    engine.start(Some(pomodoro::types::StartParams { task_name: Some("通知テスト".to_string()), ..Default::default() })).unwrap();
 
     let event = rx.try_recv();
     assert!(event.is_ok());
@@ -215,7 +215,7 @@ async fn tc_i_006_stop_event_triggers_notification() {
     let (mut engine, mut rx) = create_test_engine();
     let notification_sender = Arc::new(MockNotificationSender::new());
 
-    engine.start(Some("停止テスト".to_string())).unwrap();
+    engine.start(Some(pomodoro::types::StartParams { task_name: Some("停止テスト".to_string()), ..Default::default() })).unwrap();
     let _ = rx.try_recv();
 
     engine.stop().unwrap();
@@ -258,7 +258,7 @@ async fn tc_i_010_focus_mode_failure_fallback() {
     let focus_controller = MockFocusModeController::new(true);
 
     engine
-        .start(Some("フォールバックテスト".to_string()))
+        .start(Some(pomodoro::types::StartParams { task_name: Some("フォールバックテスト".to_string()), ..Default::default() }))
         .unwrap();
     let _ = rx.try_recv();
 
@@ -347,7 +347,7 @@ async fn integration_event_driven_flow() {
     let focus_controller = Arc::new(MockFocusModeController::new(false));
     let notification_sender = Arc::new(MockNotificationSender::new());
 
-    engine.start(Some("統合テスト".to_string())).unwrap();
+    engine.start(Some(pomodoro::types::StartParams { task_name: Some("統合テスト".to_string()), ..Default::default() })).unwrap();
 
     while let Ok(event) = rx.try_recv() {
         if let TimerEvent::WorkStarted { task_name } = event {
@@ -405,7 +405,7 @@ async fn integration_multiple_start_stop_cycles() {
     let focus_controller = Arc::new(MockFocusModeController::new(false));
 
     for i in 1..=3 {
-        engine.start(Some(format!("サイクル{}", i))).unwrap();
+        engine.start(Some(pomodoro::types::StartParams { task_name: Some(format!("サイクル{}", i)), ..Default::default() })).unwrap();
         if let Ok(TimerEvent::WorkStarted { .. }) = rx.try_recv() {
             focus_controller.enable().unwrap();
         }


### PR DESCRIPTION
## Summary
Fixes a bug where `pomodoro start` options (work time, break time, etc.) were ignored by the daemon.

## Related Issues
Closes #64

## Changes
- Modified `TimerEngine::start` to accept `Option<StartParams>` instead of just `Option<String>`.
- Updated `TimerEngine::start` to update `self.state.config` based on the provided params.
- Updated `ipc::handle_start` to pass the full `StartParams` to the engine.
- Updated tests to match the new signature and verify the fix.

## Testing
- [x] `cargo test daemon` passed
- [x] Added `test_timer_engine_start_with_options` to verify config update.
- [x] Added `test_timer_engine_start_with_invalid_options` to verify validation.