### PR TITLE
fix: デーモンにティッカー処理を追加し残り時間をカウントダウン

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,9 +118,20 @@ async fn main() -> Result<()> {
             // SoundPlayerの初期化
             let sound_player = pomodoro::sound::create_sound_player(false);
 
+            // タイマーティッカー（1秒間隔でカウントダウン）
+            let mut ticker = pomodoro::daemon::TimerEngine::create_ticker();
+
             // メインループ
             loop {
                 tokio::select! {
+                    // ティック処理（残り時間の減算）
+                    _ = ticker.tick() => {
+                        let mut engine_guard = engine.lock().await;
+                        if let Err(e) = engine_guard.process_tick() {
+                            eprintln!("Failed to process tick: {}", e);
+                        }
+                    }
+
                     // IPCリクエスト処理
                     result = server.accept() => {
                         match result {


### PR DESCRIPTION
## Summary
- デーモンのメインイベントループにティッカー処理を追加
- `pomodoro status` で残り時間が正しくカウントダウンされるように修正

## Related Issues
Closes #67

## Changes
- `src/main.rs`: `tokio::select!` ループ内に `ticker.tick()` 処理を追加
- `TimerEngine::create_ticker()` と `process_tick()` を呼び出すように修正

## Root Cause
`TimerEngine` には `create_ticker()` と `process_tick()` メソッドが実装されていたが、デーモンのメインループでこれらが呼び出されていなかった。

## Testing
- [x] `cargo test` passed (246 unit + 31 integration/e2e tests)
- [x] `cargo clippy` passed
- [x] `cargo fmt --check` passed