### PR TITLE
feat: CLI Sound Config Implementation

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -52,6 +52,24 @@ pub enum Commands {
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
+
+    /// サウンド設定を管理
+    Config(ConfigArgs),
+
+    /// システムサウンド一覧を表示
+    Sounds,
+}
+
+/// Config command arguments
+#[derive(Args, Debug, Clone)]
+pub struct ConfigArgs {
+    /// 作業完了時のサウンドを設定
+    #[arg(long)]
+    pub work_sound: Option<String>,
+
+    /// 休憩完了時のサウンドを設定
+    #[arg(long)]
+    pub break_sound: Option<String>,
 }
 
 /// start command arguments
@@ -237,5 +255,23 @@ mod tests {
         let args = vec!["pomodoro", "--verbose", "status"];
         let cli = Cli::try_parse_from(args).unwrap();
         assert!(cli.verbose);
+    }
+
+    #[test]
+    fn test_parse_sounds_command() {
+        let args = vec!["pomodoro", "sounds"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert!(matches!(cli.command, Commands::Sounds));
+    }
+
+    #[test]
+    fn test_parse_config_command() {
+        let args = vec!["pomodoro", "config", "--work-sound", "Glass"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        if let Commands::Config(args) = cli.command {
+            assert_eq!(args.work_sound, Some("Glass".to_string()));
+        } else {
+            panic!("Expected Config command");
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod commands;
 pub mod completions;
 pub mod display;
 pub mod ipc;
+pub mod sound;
 
 pub use commands::{Cli, Commands, StartArgs};
 pub use completions::generate_completions;

--- a/src/cli/sound.rs
+++ b/src/cli/sound.rs
@@ -1,0 +1,54 @@
+use crate::cli::commands::ConfigArgs;
+use crate::sound::{config::SoundConfig, SoundSource};
+use anyhow::Result;
+use colored::Colorize;
+
+pub fn handle_sounds() -> Result<()> {
+    let sounds = SoundSource::discover_system_sounds();
+
+    if sounds.is_empty() {
+        println!("システムサウンドが見つかりませんでした。");
+        return Ok(());
+    }
+
+    println!("{}", "利用可能なシステムサウンド:".bold());
+    for sound in sounds {
+        if let SoundSource::System { name, .. } = sound {
+            println!("  - {}", name);
+        } else if let SoundSource::Embedded { name } = sound {
+            println!("  - {} (Embedded)", name);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn handle_config(args: ConfigArgs) -> Result<()> {
+    let mut config =
+        SoundConfig::load().map_err(|e| anyhow::anyhow!("Failed to load config: {}", e))?;
+    let mut updated = false;
+
+    if let Some(sound) = args.work_sound {
+        config.work_end_sound = sound;
+        updated = true;
+    }
+
+    if let Some(sound) = args.break_sound {
+        config.break_end_sound = sound;
+        updated = true;
+    }
+
+    if updated {
+        config
+            .save()
+            .map_err(|e| anyhow::anyhow!("Failed to save config: {}", e))?;
+        println!("{}", "設定を更新しました。".green());
+    }
+
+    // 現在の設定を表示
+    println!("{}", "現在のサウンド設定:".bold());
+    println!("  作業完了音: {}", config.work_end_sound);
+    println!("  休憩完了音: {}", config.break_end_sound);
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,12 @@ async fn main() -> Result<()> {
             Ok(_) => display.show_success("LaunchAgent uninstalled successfully"),
             Err(e) => display.show_error(&format!("Failed to uninstall LaunchAgent: {}", e)),
         },
+        Commands::Config(args) => {
+            pomodoro::cli::sound::handle_config(args)?;
+        }
+        Commands::Sounds => {
+            pomodoro::cli::sound::handle_sounds()?;
+        }
         Commands::Daemon => {
             // デーモン設定の初期化
             let config = pomodoro::types::PomodoroConfig::default();


### PR DESCRIPTION
## Summary
Implements CLI commands for sound configuration as per Issue #75.

## Related Issues
Closes #75

## Changes
- Added `pomodoro sounds` command to list system sounds
- Added `pomodoro config` command to view and update sound settings
  - `--work-sound`: Set work completion sound
  - `--break-sound`: Set break completion sound
- Updated `SoundConfig` handling logic

## Testing
- [x] Verified `pomodoro sounds` lists dummy system sounds
- [x] Verified `pomodoro config` updates and persists settings
- [x] `cargo clippy` passed
- [x] `cargo test` passed

## Notes
Verified in container environment with mock sound files.