### PR TITLE
feat: Sound: サウンド再生ロジック拡張

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<()> {
         Commands::Daemon => {
             // デーモン設定の初期化
             let config = pomodoro::types::PomodoroConfig::default();
+            let sound_config = pomodoro::sound::SoundConfig::load().unwrap_or_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
             // TimerEngineの初期化
@@ -177,7 +178,11 @@ async fn main() -> Result<()> {
                                     }
                                 }
 
-                                if let Err(e) = sound_player.play(&pomodoro::sound::SoundSource::Embedded { name: "default".to_string() }).await {
+                                let sound_name = &sound_config.work_end_sound;
+                                let source = pomodoro::sound::SoundSource::find_by_name(sound_name)
+                                    .unwrap_or(pomodoro::sound::SoundSource::Embedded { name: "default".to_string() });
+
+                                if let Err(e) = sound_player.play(&source).await {
                                     eprintln!("Failed to play sound: {}", e);
                                 }
                             }
@@ -189,7 +194,11 @@ async fn main() -> Result<()> {
                                     }
                                 }
 
-                                if let Err(e) = sound_player.play(&pomodoro::sound::SoundSource::Embedded { name: "default".to_string() }).await {
+                                let sound_name = &sound_config.break_end_sound;
+                                let source = pomodoro::sound::SoundSource::find_by_name(sound_name)
+                                    .unwrap_or(pomodoro::sound::SoundSource::Embedded { name: "default".to_string() });
+
+                                if let Err(e) = sound_player.play(&source).await {
                                     eprintln!("Failed to play sound: {}", e);
                                 }
                             }


### PR DESCRIPTION
## 概要
Closes #76

TimerPhase（作業終了/休憩終了）に応じたサウンド再生ロジックを実装しました。
`~/.pomodoro/sound-config.json` で設定されたサウンド名に基づいて、システムサウンドまたは埋め込みサウンドを再生します。

## 変更内容
- `src/sound/source.rs`: `SoundSource::find_by_name` を追加。名前からサウンドソースを解決します。
- `src/main.rs`: デーモン起動時に `SoundConfig` を読み込み、`TimerEvent` 発生時に設定されたサウンドを再生するように変更しました。

## テスト結果
- `cargo test sound::source` 通過（システムサウンド検索含む）
- `cargo check --bin pomodoro` 通過

## 補足
Docker環境の不具合により、ホスト環境で実装・検証を行いました（Platform Exception: macOSシステムサウンド依存のため）。