### PR TITLE
feat(hooks): HookContextユニットテストとサニタイズ実装

### DIFF
--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -41,10 +41,13 @@ impl HookContext {
         );
 
         if let Some(ref name) = self.task_name {
-            vars.insert("POMODORO_TASK_NAME".to_string(), name.clone());
+            vars.insert("POMODORO_TASK_NAME".to_string(), Self::sanitize_value(name));
         }
 
-        vars.insert("POMODORO_PHASE".to_string(), self.phase.clone());
+        vars.insert(
+            "POMODORO_PHASE".to_string(),
+            Self::sanitize_value(&self.phase),
+        );
         vars.insert(
             "POMODORO_DURATION_SECS".to_string(),
             self.duration_secs.to_string(),
@@ -72,5 +75,106 @@ impl HookContext {
         );
 
         vars
+    }
+
+    /// 値をサニタイズする（シェルで安全に使用できるように）
+    fn sanitize_value(value: &str) -> String {
+        value
+            .chars()
+            .filter(|c| c.is_alphanumeric() || [' ', '-', '_', '.', ':', '/'].contains(c))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::str::FromStr;
+
+    fn create_test_context() -> HookContext {
+        HookContext {
+            event: HookEvent::WorkStart,
+            task_name: Some("Test Task".to_string()),
+            phase: "Work".to_string(),
+            duration_secs: 1500,
+            elapsed_secs: 0,
+            remaining_secs: 1500,
+            cycle: 1,
+            total_cycles: 4,
+            timestamp: Utc.timestamp_opt(1672531200, 0).unwrap(), // 2023-01-01 00:00:00 UTC
+            session_id: Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_to_env_vars_basic() {
+        let context = create_test_context();
+        let vars = context.to_env_vars();
+
+        assert_eq!(vars.get("POMODORO_EVENT"), Some(&"work_start".to_string()));
+        assert_eq!(
+            vars.get("POMODORO_TASK_NAME"),
+            Some(&"Test Task".to_string())
+        );
+        assert_eq!(vars.get("POMODORO_PHASE"), Some(&"Work".to_string()));
+        assert_eq!(
+            vars.get("POMODORO_DURATION_SECS"),
+            Some(&"1500".to_string())
+        );
+        assert_eq!(vars.get("POMODORO_ELAPSED_SECS"), Some(&"0".to_string()));
+        assert_eq!(
+            vars.get("POMODORO_REMAINING_SECS"),
+            Some(&"1500".to_string())
+        );
+        assert_eq!(vars.get("POMODORO_CYCLE"), Some(&"1".to_string()));
+        assert_eq!(vars.get("POMODORO_TOTAL_CYCLES"), Some(&"4".to_string()));
+        assert_eq!(
+            vars.get("POMODORO_TIMESTAMP"),
+            Some(&"2023-01-01T00:00:00+00:00".to_string())
+        );
+        assert_eq!(
+            vars.get("POMODORO_SESSION_ID"),
+            Some(&"00000000-0000-0000-0000-000000000000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_to_env_vars_no_task_name() {
+        let mut context = create_test_context();
+        context.task_name = None;
+        let vars = context.to_env_vars();
+
+        assert!(!vars.contains_key("POMODORO_TASK_NAME"));
+    }
+
+    #[test]
+    fn test_sanitize_values() {
+        let mut context = create_test_context();
+        context.task_name = Some("Task; rm -rf /".to_string());
+        context.phase = "Phase `echo hack`".to_string();
+
+        let vars = context.to_env_vars();
+
+        // セミコロンやバッククォートが除去されていることを確認
+        assert_eq!(
+            vars.get("POMODORO_TASK_NAME"),
+            Some(&"Task rm -rf /".to_string())
+        );
+        assert_eq!(
+            vars.get("POMODORO_PHASE"),
+            Some(&"Phase echo hack".to_string())
+        );
+    }
+
+    #[test]
+    fn test_sanitize_shell_vars() {
+        let mut context = create_test_context();
+        context.task_name = Some("$VAR ${VAR}".to_string());
+
+        let vars = context.to_env_vars();
+
+        // $ や {} が除去されていること
+        assert_eq!(vars.get("POMODORO_TASK_NAME"), Some(&"VAR VAR".to_string()));
     }
 }


### PR DESCRIPTION
## 概要
Closes #102

HookContextのユニットテストと、環境変数生成時のサニタイズ処理を実装しました。

## 変更内容
- `src/hooks/context.rs` に `#[cfg(test)] mod tests` を追加
- `HookContext::to_env_vars` メソッドに `sanitize_value` 処理を追加
    - 英数字と安全な記号以外を除去するホワイトリスト方式

## テスト結果
- 全テスト通過: ✅
- Clippy警告: なし
- Format: OK
