### PR TITLE
docs: USAGE.mdにイベントフックセクションを追加

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -125,6 +125,122 @@ pomodoro config --work-sound Pop
 pomodoro config --break-sound Basso
 ```
 
+## イベントフック
+
+タイマーイベント発生時にカスタムスクリプトを実行できます。Slack通知、統計記録、BGM制御など、自由に拡張可能です。
+
+### 対応イベント
+
+| イベント名 | 説明 |
+|------------|------|
+| `work_start` | 作業セッション開始時 |
+| `work_end` | 作業セッション終了時 |
+| `break_start` | 短い休憩開始時 |
+| `break_end` | 短い休憩終了時 |
+| `long_break_start` | 長い休憩開始時 |
+| `long_break_end` | 長い休憩終了時 |
+| `pause` | タイマー一時停止時 |
+| `resume` | タイマー再開時 |
+| `stop` | タイマー停止時 |
+
+### 設定ファイル
+
+`~/.pomodoro/hooks.json` にフック定義を記述します。
+
+```json
+{
+  "version": "1.0",
+  "hooks": [
+    {
+      "name": "slack-notify",
+      "event": "work_end",
+      "script": "~/.pomodoro/scripts/slack-notify.sh",
+      "timeout_secs": 30,
+      "enabled": true
+    },
+    {
+      "name": "log-stats",
+      "event": "work_end",
+      "script": "~/.pomodoro/scripts/log-stats.sh",
+      "timeout_secs": 10,
+      "enabled": true
+    }
+  ],
+  "defaults": {
+    "timeout_secs": 30
+  }
+}
+```
+
+### フック定義の各フィールド
+
+| フィールド | 必須 | デフォルト | 説明 |
+|------------|------|------------|------|
+| `name` | ○ | - | フックの識別名（ログ出力に使用） |
+| `event` | ○ | - | トリガーするイベント名 |
+| `script` | ○ | - | 実行するスクリプトのパス（絶対パスまたは`~/`形式） |
+| `timeout_secs` | - | 30 | タイムアウト秒数（1-300） |
+| `enabled` | - | true | 有効/無効フラグ |
+
+### 環境変数
+
+スクリプト実行時に以下の環境変数が設定されます。
+
+| 変数名 | 説明 | 例 |
+|--------|------|-----|
+| `POMODORO_EVENT` | イベント種別 | `work_end` |
+| `POMODORO_PHASE` | 現在のフェーズ | `Working`, `ShortBreak` |
+| `POMODORO_TASK_NAME` | タスク名（設定時のみ） | `ドキュメント作成` |
+| `POMODORO_CYCLE` | 現在のサイクル番号 | `2` |
+| `POMODORO_TOTAL_CYCLES` | 総サイクル数 | `4` |
+| `POMODORO_DURATION_SECS` | セッション全体の秒数 | `1500` |
+| `POMODORO_ELAPSED_SECS` | 経過秒数 | `1500` |
+| `POMODORO_REMAINING_SECS` | 残り秒数 | `0` |
+| `POMODORO_TIMESTAMP` | イベント発生時刻（ISO8601） | `2026-01-06T15:30:00Z` |
+| `POMODORO_SESSION_ID` | セッションID（UUID） | `550e8400-e29b-41d4-...` |
+| `POMODORO_HOOK_NAME` | 実行中のフック名 | `slack-notify` |
+
+### 使用例：Slack通知
+
+`~/.pomodoro/scripts/slack-notify.sh`:
+
+```bash
+#!/bin/bash
+
+# Slack Webhook URL（環境変数で設定）
+WEBHOOK_URL="${SLACK_WEBHOOK_URL}"
+
+case "$POMODORO_EVENT" in
+  work_end)
+    MESSAGE=":tomato: ポモドーロ #${POMODORO_CYCLE} 完了！休憩しましょう。"
+    ;;
+  break_end)
+    MESSAGE=":muscle: 休憩終了！次のポモドーロを始めましょう。"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+curl -s -X POST -H 'Content-type: application/json' \
+  --data "{\"text\": \"${MESSAGE}\"}" \
+  "$WEBHOOK_URL"
+```
+
+スクリプトに実行権限を付与:
+
+```bash
+chmod +x ~/.pomodoro/scripts/slack-notify.sh
+```
+
+### 注意事項
+
+- フックは**非同期**で実行されます（タイマーをブロックしません）
+- スクリプトは**絶対パス**または**`~/`で始まるパス**で指定してください
+- 相対パスは使用できません（セキュリティ対策）
+- 1イベントあたり最大**10個**のフックを登録可能
+- タイムアウトは**1〜300秒**の範囲で指定
+
 ## 設定オプション
 
 ### サウンド設定


### PR DESCRIPTION
## 概要
USAGE.mdにイベントフック機能の使用方法を追加しました。

Closes #105

## 変更内容

### 追加セクション
1. **対応イベント一覧** - 9種類のタイマーイベント
2. **設定ファイル説明** - `~/.pomodoro/hooks.json` の書式
3. **フック定義フィールド** - name, event, script, timeout_secs, enabled
4. **環境変数一覧** - 11種類の変数とその説明
5. **使用例** - Slack通知スクリプトのサンプル
6. **注意事項** - 非同期実行、パス指定、制限値

## 整合性確認
- [x] `src/hooks/config.rs` との整合性確認（イベント名、フィールド名）
- [x] `src/hooks/executor.rs` との整合性確認（環境変数名）

## チェックリスト
- [x] 既存フォーマットとの整合性
- [x] 実装コードとの整合性