### PR TITLE
docs: イベントフック用サンプルスクリプトを追加

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -241,6 +241,17 @@ chmod +x ~/.pomodoro/scripts/slack-notify.sh
 - 1イベントあたり最大**10個**のフックを登録可能
 - タイムアウトは**1〜300秒**の範囲で指定
 
+### サンプルスクリプト
+
+`examples/hooks/` ディレクトリにサンプルスクリプトが用意されています:
+
+| スクリプト | 説明 |
+|-----------|------|
+| `slack-notify.sh` | Slack Webhook通知 |
+| `desktop-notify.sh` | macOSデスクトップ通知 |
+| `record-stats.sh` | CSV統計記録 |
+| `bgm-control.sh` | BGM自動制御（Spotify/Music） |
+
 ## 設定オプション
 
 ### サウンド設定

--- a/examples/hooks/bgm-control.sh
+++ b/examples/hooks/bgm-control.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# =============================================================================
+# bgm-control.sh - BGM制御フック
+# =============================================================================
+# 
+# 概要:
+#   ポモドーロタイマーのイベントに応じてBGMを自動制御するスクリプト
+#   作業開始時に音楽を再生し、休憩開始時に一時停止します
+#
+# 対応アプリ:
+#   - Spotify
+#   - Apple Music (ミュージック)
+#
+# 使用方法:
+#   1. このスクリプトに実行権限を付与: chmod +x bgm-control.sh
+#   2. 環境変数 POMODORO_BGM_APP で使用するアプリを指定（オプション）
+#      設定値: "spotify" または "music"
+#      デフォルト: 両方のアプリを試行
+#   3. ポモドーロタイマーの設定でフックとして登録:
+#      pomodoro config hooks.work_start "path/to/bgm-control.sh"
+#      pomodoro config hooks.break_start "path/to/bgm-control.sh"
+#
+# 環境変数（ポモドーロタイマーから自動設定）:
+#   POMODORO_EVENT - イベント名
+#
+# 注意:
+#   - このスクリプトはmacOS専用です
+#   - 音楽アプリが起動している必要があります
+#
+# =============================================================================
+
+set -euo pipefail
+
+# 使用するアプリ（spotify, music, または空欄で自動検出）
+BGM_APP="${POMODORO_BGM_APP:-}"
+
+# Spotifyを制御
+control_spotify() {
+    local action="$1"
+    if pgrep -x "Spotify" > /dev/null; then
+        osascript -e "tell application \"Spotify\" to ${action}"
+        return 0
+    fi
+    return 1
+}
+
+# Apple Musicを制御
+control_music() {
+    local action="$1"
+    if pgrep -x "Music" > /dev/null; then
+        osascript -e "tell application \"Music\" to ${action}"
+        return 0
+    fi
+    return 1
+}
+
+# 音楽を再生
+play_music() {
+    case "$BGM_APP" in
+        spotify)
+            control_spotify "play" && echo "Spotify: Playing" && return
+            ;;
+        music)
+            control_music "play" && echo "Music: Playing" && return
+            ;;
+        *)
+            # 自動検出: Spotifyを優先
+            control_spotify "play" && echo "Spotify: Playing" && return
+            control_music "play" && echo "Music: Playing" && return
+            ;;
+    esac
+    echo "No music app is running"
+}
+
+# 音楽を一時停止
+pause_music() {
+    case "$BGM_APP" in
+        spotify)
+            control_spotify "pause" && echo "Spotify: Paused" && return
+            ;;
+        music)
+            control_music "pause" && echo "Music: Paused" && return
+            ;;
+        *)
+            # 両方を一時停止
+            control_spotify "pause" 2>/dev/null && echo "Spotify: Paused"
+            control_music "pause" 2>/dev/null && echo "Music: Paused"
+            ;;
+    esac
+}
+
+# イベントに応じた制御
+case "${POMODORO_EVENT:-}" in
+    work_start)
+        echo "Starting BGM for work session..."
+        play_music
+        ;;
+    break_start)
+        echo "Pausing BGM for break..."
+        pause_music
+        ;;
+    break_end)
+        echo "Resuming BGM for next session..."
+        play_music
+        ;;
+    session_complete)
+        echo "Session complete, pausing BGM..."
+        pause_music
+        ;;
+    *)
+        echo "No BGM action for event: ${POMODORO_EVENT:-unknown}"
+        ;;
+esac

--- a/examples/hooks/desktop-notify.sh
+++ b/examples/hooks/desktop-notify.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# =============================================================================
+# desktop-notify.sh - macOSデスクトップ通知フック
+# =============================================================================
+# 
+# 概要:
+#   ポモドーロタイマーのイベントをmacOSの通知センターに表示するスクリプト
+#   osascript（AppleScript）を使用
+#
+# 使用方法:
+#   1. このスクリプトに実行権限を付与: chmod +x desktop-notify.sh
+#   2. ポモドーロタイマーの設定でフックとして登録:
+#      pomodoro config hooks.work_end "path/to/desktop-notify.sh"
+#
+# 環境変数（ポモドーロタイマーから自動設定）:
+#   POMODORO_EVENT        - イベント名
+#   POMODORO_TASK_NAME    - タスク名
+#   POMODORO_CURRENT_CYCLE - 現在のサイクル数
+#   POMODORO_TOTAL_CYCLES  - 総サイクル数
+#
+# 注意:
+#   このスクリプトはmacOS専用です
+#
+# =============================================================================
+
+set -euo pipefail
+
+# イベントに応じたタイトルとメッセージ
+case "${POMODORO_EVENT:-}" in
+    work_start)
+        title="🍅 作業開始"
+        message="${POMODORO_TASK_NAME:-タスク名なし}"
+        sound="Blow"
+        ;;
+    work_end)
+        title="✅ 作業完了"
+        message="休憩を取りましょう (${POMODORO_CURRENT_CYCLE:-?}/${POMODORO_TOTAL_CYCLES:-?})"
+        sound="Glass"
+        ;;
+    break_start)
+        title="☕ 休憩開始"
+        message="リフレッシュしましょう"
+        sound="Breeze"
+        ;;
+    break_end)
+        title="💪 休憩終了"
+        message="次のポモドーロを始めましょう！"
+        sound="Blow"
+        ;;
+    session_complete)
+        title="🎉 セッション完了"
+        message="お疲れ様でした！"
+        sound="Fanfare"
+        ;;
+    *)
+        title="🔔 ポモドーロ"
+        message="イベント: ${POMODORO_EVENT:-unknown}"
+        sound="Default"
+        ;;
+esac
+
+# macOS通知を表示
+osascript -e "display notification \"${message}\" with title \"${title}\" sound name \"${sound}\""
+
+echo "Desktop notification displayed: ${title} - ${message}"

--- a/examples/hooks/record-stats.sh
+++ b/examples/hooks/record-stats.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# =============================================================================
+# record-stats.sh - 統計記録フック
+# =============================================================================
+# 
+# 概要:
+#   ポモドーロタイマーのイベントをCSVファイルに記録するスクリプト
+#   作業時間やタスクの統計を後から分析できます
+#
+# 使用方法:
+#   1. このスクリプトに実行権限を付与: chmod +x record-stats.sh
+#   2. 環境変数 POMODORO_STATS_FILE で出力先を指定（オプション）
+#      デフォルト: ~/pomodoro-stats.csv
+#   3. ポモドーロタイマーの設定でフックとして登録:
+#      pomodoro config hooks.work_end "path/to/record-stats.sh"
+#      pomodoro config hooks.session_complete "path/to/record-stats.sh"
+#
+# 環境変数（ポモドーロタイマーから自動設定）:
+#   POMODORO_EVENT          - イベント名
+#   POMODORO_TASK_NAME      - タスク名
+#   POMODORO_PHASE          - 現在のフェーズ (work, short_break, long_break)
+#   POMODORO_WORK_DURATION  - 作業時間（秒）
+#   POMODORO_BREAK_DURATION - 休憩時間（秒）
+#   POMODORO_ELAPSED_SECS   - 経過時間（秒）
+#   POMODORO_CURRENT_CYCLE  - 現在のサイクル数
+#   POMODORO_TOTAL_CYCLES   - 総サイクル数
+#   POMODORO_SESSION_ID     - セッションID
+#   POMODORO_TIMESTAMP      - イベント発生時刻 (ISO 8601形式)
+#
+# 出力CSV形式:
+#   timestamp,event,task_name,phase,cycle,total_cycles,elapsed_secs,session_id
+#
+# =============================================================================
+
+set -euo pipefail
+
+# 出力先ファイル
+STATS_FILE="${POMODORO_STATS_FILE:-$HOME/pomodoro-stats.csv}"
+
+# ファイルが存在しない場合はヘッダーを追加
+if [[ ! -f "$STATS_FILE" ]]; then
+    echo "timestamp,event,task_name,phase,cycle,total_cycles,elapsed_secs,session_id" > "$STATS_FILE"
+fi
+
+# タスク名のエスケープ（カンマと改行を処理）
+task_name="${POMODORO_TASK_NAME:-}"
+task_name="${task_name//,/;}"  # カンマをセミコロンに置換
+task_name="${task_name//$'\n'/ }"  # 改行をスペースに置換
+
+# CSVレコードを追記
+echo "${POMODORO_TIMESTAMP:-$(date -u +%Y-%m-%dT%H:%M:%SZ)},\
+${POMODORO_EVENT:-unknown},\
+${task_name},\
+${POMODORO_PHASE:-},\
+${POMODORO_CURRENT_CYCLE:-0},\
+${POMODORO_TOTAL_CYCLES:-0},\
+${POMODORO_ELAPSED_SECS:-0},\
+${POMODORO_SESSION_ID:-}" >> "$STATS_FILE"
+
+echo "Stats recorded to: ${STATS_FILE}"
+
+# 今日の統計サマリーを表示（work_endイベント時のみ）
+if [[ "${POMODORO_EVENT:-}" == "session_complete" ]]; then
+    today=$(date +%Y-%m-%d)
+    completed_today=$(grep "^${today}" "$STATS_FILE" | grep -c "work_end" || echo "0")
+    echo "Today's completed pomodoros: ${completed_today}"
+fi

--- a/examples/hooks/slack-notify.sh
+++ b/examples/hooks/slack-notify.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# =============================================================================
+# slack-notify.sh - Slack通知フック
+# =============================================================================
+# 
+# 概要:
+#   ポモドーロタイマーのイベントをSlackに通知するスクリプト
+#
+# 使用方法:
+#   1. Slack Incoming Webhook URLを取得
+#      https://api.slack.com/messaging/webhooks
+#   2. 環境変数 SLACK_WEBHOOK_URL を設定
+#   3. このスクリプトに実行権限を付与: chmod +x slack-notify.sh
+#   4. ポモドーロタイマーの設定でフックとして登録:
+#      pomodoro config hooks.work_end "path/to/slack-notify.sh"
+#
+# 環境変数（ポモドーロタイマーから自動設定）:
+#   POMODORO_EVENT        - イベント名 (work_start, work_end, break_start, break_end, etc.)
+#   POMODORO_TASK_NAME    - タスク名
+#   POMODORO_CURRENT_CYCLE - 現在のサイクル数
+#   POMODORO_TOTAL_CYCLES  - 総サイクル数
+#   POMODORO_TIMESTAMP    - イベント発生時刻 (ISO 8601形式)
+#
+# =============================================================================
+
+set -euo pipefail
+
+# Slack Webhook URL（環境変数から取得）
+WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"
+
+if [[ -z "$WEBHOOK_URL" ]]; then
+    echo "Error: SLACK_WEBHOOK_URL is not set" >&2
+    exit 1
+fi
+
+# イベントに応じたメッセージとアイコン
+case "${POMODORO_EVENT:-}" in
+    work_start)
+        emoji=":tomato:"
+        message="作業開始: ${POMODORO_TASK_NAME:-タスク名なし}"
+        ;;
+    work_end)
+        emoji=":white_check_mark:"
+        message="作業完了！休憩を取りましょう (${POMODORO_CURRENT_CYCLE:-?}/${POMODORO_TOTAL_CYCLES:-?})"
+        ;;
+    break_start)
+        emoji=":coffee:"
+        message="休憩開始: リフレッシュしましょう"
+        ;;
+    break_end)
+        emoji=":muscle:"
+        message="休憩終了: 次のポモドーロを始めましょう！"
+        ;;
+    session_complete)
+        emoji=":tada:"
+        message="セッション完了！お疲れ様でした！"
+        ;;
+    *)
+        emoji=":bell:"
+        message="ポモドーロイベント: ${POMODORO_EVENT:-unknown}"
+        ;;
+esac
+
+# Slackに通知を送信
+payload=$(cat <<EOF
+{
+    "text": "${emoji} ${message}",
+    "username": "Pomodoro Timer",
+    "icon_emoji": ":tomato:"
+}
+EOF
+)
+
+curl -s -X POST -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$WEBHOOK_URL" > /dev/null
+
+echo "Slack notification sent: ${message}"


### PR DESCRIPTION
## Summary
- イベントフック用の4つのサンプルスクリプトを追加
- USAGE.mdにサンプルスクリプト一覧を追加

## Related Issues
Closes #107

## Changes
- `examples/hooks/slack-notify.sh`: Slack Webhook通知
- `examples/hooks/desktop-notify.sh`: macOSデスクトップ通知
- `examples/hooks/record-stats.sh`: CSV統計記録
- `examples/hooks/bgm-control.sh`: BGM自動制御（Spotify/Music）
- USAGE.mdに「サンプルスクリプト」セクションを追加

## Testing
- [x] すべてのスクリプトに実行権限付与済み
- [x] シェルスクリプトの構文確認済み
- [x] USAGE.mdからの参照確認済み

## Parent Issue
- Epic: #96 [Docs] イベントフック機能ドキュメント更新
- 親Epic: #91 [Epic] イベントフック機能