### PR TITLE
feat: [F-037] LayoutRenderer: 3行レイアウト構築

### DIFF
--- a/src/cli/layout.rs
+++ b/src/cli/layout.rs
@@ -1,17 +1,536 @@
-// スタブ実装
+//! レイアウトレンダラーモジュール
+//!
+//! インジケーター、時間表示、アニメーション、タスク名を3行構成のレイアウトに統合する。
+
+use crate::cli::animation::AnimationFrame;
+use crate::cli::time_format::TimeDisplay;
+use crate::types::TimerPhase;
+use colored::Colorize;
+use unicode_width::UnicodeWidthStr;
+
+/// 3行レイアウトの構造
+#[derive(Debug, Clone)]
 pub struct DisplayLayout {
-    // 仮のフィールド
-    pub lines: Vec<String>,
+    /// 1行目: フェーズ＋インジケーター＋時間
+    pub line1: String,
+    /// 2行目: アニメーション
+    pub line2: String,
+    /// 3行目: タスク名（オプション）
+    pub line3: Option<String>,
+    /// 行数（2 or 3）
+    pub line_count: usize,
 }
 
 impl DisplayLayout {
-    pub fn new() -> Self {
-        Self { lines: Vec::new() }
+    /// レイアウトを作成
+    pub fn new(line1: String, line2: String, line3: Option<String>) -> Self {
+        let line_count = if line3.is_some() { 3 } else { 2 };
+        Self {
+            line1,
+            line2,
+            line3,
+            line_count,
+        }
+    }
+
+    /// 全行をベクタで取得
+    pub fn lines(&self) -> Vec<&str> {
+        let mut result = vec![self.line1.as_str(), self.line2.as_str()];
+        if let Some(ref line3) = self.line3 {
+            result.push(line3.as_str());
+        }
+        result
+    }
+
+    /// 最大行幅を取得
+    pub fn max_width(&self) -> usize {
+        let mut max = UnicodeWidthStr::width(self.line1.as_str());
+        max = max.max(UnicodeWidthStr::width(self.line2.as_str()));
+        if let Some(ref line3) = self.line3 {
+            max = max.max(UnicodeWidthStr::width(line3.as_str()));
+        }
+        max
     }
 }
 
 impl Default for DisplayLayout {
     fn default() -> Self {
-        Self::new()
+        Self::new(String::new(), String::new(), None)
+    }
+}
+
+/// レイアウトレンダラー
+pub struct LayoutRenderer {
+    /// ターミナル幅（80文字未満で簡略表示）
+    terminal_width: usize,
+    /// プログレスバー幅
+    bar_width: usize,
+}
+
+impl LayoutRenderer {
+    /// 新しいLayoutRendererを作成
+    pub fn new(terminal_width: usize) -> Self {
+        // プログレスバー幅を計算（ターミナル幅の40%、最大40文字）
+        let bar_width = ((terminal_width as f32) * 0.4).min(40.0) as usize;
+        Self {
+            terminal_width,
+            bar_width,
+        }
+    }
+
+    /// デフォルトのターミナル幅（80文字）で作成
+    pub fn with_default_width() -> Self {
+        Self::new(80)
+    }
+
+    /// ターミナル幅を取得
+    pub fn terminal_width(&self) -> usize {
+        self.terminal_width
+    }
+
+    /// プログレスバー幅を取得
+    pub fn bar_width(&self) -> usize {
+        self.bar_width
+    }
+
+    /// レイアウトを構築
+    ///
+    /// # Arguments
+    /// * `phase` - 現在のフェーズ
+    /// * `time_display` - 時間表示情報
+    /// * `animation_frame` - アニメーションフレーム
+    /// * `task_name` - タスク名（オプション）
+    /// * `progress_position` - プログレス位置
+    /// * `progress_total` - プログレス合計
+    pub fn build_layout(
+        &self,
+        phase: TimerPhase,
+        time_display: &TimeDisplay,
+        animation_frame: Option<&AnimationFrame>,
+        task_name: Option<&str>,
+        progress_position: u64,
+        progress_total: u64,
+    ) -> DisplayLayout {
+        // 1行目: フェーズ + プログレスバー + 時間
+        let line1 = self.build_line1(phase, time_display, progress_position, progress_total);
+
+        // 2行目: アニメーション
+        let line2 = match animation_frame {
+            Some(frame) => frame.content.clone(),
+            None => String::new(),
+        };
+
+        // 3行目: タスク名
+        let line3 = task_name.map(|name| format!("タスク: {}", name.cyan()));
+
+        DisplayLayout::new(line1, line2, line3)
+    }
+
+    /// 1行目を構築
+    fn build_line1(
+        &self,
+        phase: TimerPhase,
+        time_display: &TimeDisplay,
+        position: u64,
+        total: u64,
+    ) -> String {
+        let (icon, label, color) = Self::phase_style(phase);
+
+        // プログレスバーを構築
+        let bar = self.build_progress_bar(position, total);
+
+        // 時間表示
+        let time_str = time_display.format();
+
+        // フェーズ表示（色付き）
+        let phase_str = format!("{} {}", icon, label);
+        let colored_phase = match color {
+            "red" => phase_str.red().to_string(),
+            "green" => phase_str.green().to_string(),
+            "blue" => phase_str.blue().to_string(),
+            "yellow" => phase_str.yellow().to_string(),
+            _ => phase_str.white().to_string(),
+        };
+
+        format!("{} {} {}", colored_phase, bar, time_str)
+    }
+
+    /// プログレスバーを構築
+    fn build_progress_bar(&self, position: u64, total: u64) -> String {
+        if total == 0 {
+            return format!("[{}]", "░".repeat(self.bar_width));
+        }
+
+        let filled = ((position as f64 / total as f64) * self.bar_width as f64) as usize;
+        let empty = self.bar_width.saturating_sub(filled);
+
+        format!("[{}{}]", "█".repeat(filled), "░".repeat(empty))
+    }
+
+    /// フェーズのスタイルを取得
+    pub fn phase_style(phase: TimerPhase) -> (&'static str, &'static str, &'static str) {
+        match phase {
+            TimerPhase::Working => ("🍅", "作業中", "red"),
+            TimerPhase::Breaking => ("☕", "休憩中", "green"),
+            TimerPhase::LongBreaking => ("🛏️", "長期休憩中", "blue"),
+            TimerPhase::Paused => ("⏸️", "一時停止", "yellow"),
+            TimerPhase::Stopped => ("⏹", "停止", "white"),
+        }
+    }
+
+    /// ターミナル幅を更新
+    pub fn set_terminal_width(&mut self, width: usize) {
+        self.terminal_width = width;
+        self.bar_width = ((width as f32) * 0.4).min(40.0) as usize;
+    }
+
+    /// 独自レンダリング（indicatif非使用）
+    pub fn render_standalone(&self, layout: &DisplayLayout) -> String {
+        let mut output = String::new();
+        output.push_str(&layout.line1);
+        output.push('\n');
+        output.push_str(&layout.line2);
+        if let Some(ref line3) = layout.line3 {
+            output.push('\n');
+            output.push_str(line3);
+        }
+        output
+    }
+}
+
+impl Default for LayoutRenderer {
+    fn default() -> Self {
+        Self::with_default_width()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------------
+    // DisplayLayout Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_display_layout_new_with_task() {
+        let layout = DisplayLayout::new(
+            "line1".to_string(),
+            "line2".to_string(),
+            Some("line3".to_string()),
+        );
+        assert_eq!(layout.line_count, 3);
+        assert_eq!(layout.line1, "line1");
+        assert_eq!(layout.line2, "line2");
+        assert_eq!(layout.line3, Some("line3".to_string()));
+    }
+
+    #[test]
+    fn test_display_layout_new_without_task() {
+        let layout = DisplayLayout::new("line1".to_string(), "line2".to_string(), None);
+        assert_eq!(layout.line_count, 2);
+        assert!(layout.line3.is_none());
+    }
+
+    #[test]
+    fn test_display_layout_lines_with_task() {
+        let layout = DisplayLayout::new(
+            "a".to_string(),
+            "b".to_string(),
+            Some("c".to_string()),
+        );
+        let lines = layout.lines();
+        assert_eq!(lines, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_display_layout_lines_without_task() {
+        let layout = DisplayLayout::new("a".to_string(), "b".to_string(), None);
+        let lines = layout.lines();
+        assert_eq!(lines, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_display_layout_max_width() {
+        let layout = DisplayLayout::new(
+            "short".to_string(),
+            "medium text".to_string(),
+            Some("longest text here".to_string()),
+        );
+        assert_eq!(layout.max_width(), 17); // "longest text here" = 17
+    }
+
+    #[test]
+    fn test_display_layout_max_width_unicode() {
+        let layout = DisplayLayout::new(
+            "日本語".to_string(), // 6 width (3 chars * 2)
+            "test".to_string(),   // 4 width
+            None,
+        );
+        assert_eq!(layout.max_width(), 6);
+    }
+
+    #[test]
+    fn test_display_layout_default() {
+        let layout = DisplayLayout::default();
+        assert_eq!(layout.line1, "");
+        assert_eq!(layout.line2, "");
+        assert!(layout.line3.is_none());
+        assert_eq!(layout.line_count, 2);
+    }
+
+    // ------------------------------------------------------------------------
+    // LayoutRenderer Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_layout_renderer_new() {
+        let renderer = LayoutRenderer::new(80);
+        assert_eq!(renderer.terminal_width(), 80);
+        assert_eq!(renderer.bar_width(), 32); // 80 * 0.4 = 32
+    }
+
+    #[test]
+    fn test_layout_renderer_new_narrow() {
+        let renderer = LayoutRenderer::new(40);
+        assert_eq!(renderer.terminal_width(), 40);
+        assert_eq!(renderer.bar_width(), 16); // 40 * 0.4 = 16
+    }
+
+    #[test]
+    fn test_layout_renderer_new_wide() {
+        let renderer = LayoutRenderer::new(120);
+        assert_eq!(renderer.terminal_width(), 120);
+        assert_eq!(renderer.bar_width(), 40); // capped at 40
+    }
+
+    #[test]
+    fn test_layout_renderer_with_default_width() {
+        let renderer = LayoutRenderer::with_default_width();
+        assert_eq!(renderer.terminal_width(), 80);
+    }
+
+    #[test]
+    fn test_layout_renderer_default() {
+        let renderer = LayoutRenderer::default();
+        assert_eq!(renderer.terminal_width(), 80);
+    }
+
+    #[test]
+    fn test_layout_renderer_build_layout_working() {
+        let renderer = LayoutRenderer::new(80);
+        let time_display = TimeDisplay::new(323, 1500);
+        let frame = AnimationFrame::new("🏃💨 ─────");
+
+        let layout = renderer.build_layout(
+            TimerPhase::Working,
+            &time_display,
+            Some(&frame),
+            Some("テストタスク"),
+            323,
+            1500,
+        );
+
+        assert!(layout.line1.contains("作業中"));
+        assert!(layout.line2.contains("🏃"));
+        assert!(layout.line3.is_some());
+        assert_eq!(layout.line_count, 3);
+    }
+
+    #[test]
+    fn test_layout_renderer_build_layout_without_animation() {
+        let renderer = LayoutRenderer::new(80);
+        let time_display = TimeDisplay::new(0, 1500);
+
+        let layout = renderer.build_layout(
+            TimerPhase::Working,
+            &time_display,
+            None,
+            None,
+            0,
+            1500,
+        );
+
+        assert!(layout.line1.contains("作業中"));
+        assert_eq!(layout.line2, "");
+        assert!(layout.line3.is_none());
+        assert_eq!(layout.line_count, 2);
+    }
+
+    #[test]
+    fn test_layout_renderer_build_layout_breaking() {
+        let renderer = LayoutRenderer::new(80);
+        let time_display = TimeDisplay::new(60, 300);
+
+        let layout = renderer.build_layout(
+            TimerPhase::Breaking,
+            &time_display,
+            None,
+            None,
+            60,
+            300,
+        );
+
+        assert!(layout.line1.contains("休憩中"));
+    }
+
+    #[test]
+    fn test_layout_renderer_build_layout_long_breaking() {
+        let renderer = LayoutRenderer::new(80);
+        let time_display = TimeDisplay::new(0, 900);
+
+        let layout = renderer.build_layout(
+            TimerPhase::LongBreaking,
+            &time_display,
+            None,
+            None,
+            0,
+            900,
+        );
+
+        assert!(layout.line1.contains("長期休憩中"));
+    }
+
+    #[test]
+    fn test_layout_renderer_build_layout_paused() {
+        let renderer = LayoutRenderer::new(80);
+        let time_display = TimeDisplay::new(500, 1500);
+
+        let layout = renderer.build_layout(
+            TimerPhase::Paused,
+            &time_display,
+            None,
+            None,
+            500,
+            1500,
+        );
+
+        assert!(layout.line1.contains("一時停止"));
+    }
+
+    #[test]
+    fn test_layout_renderer_build_layout_stopped() {
+        let renderer = LayoutRenderer::new(80);
+        let time_display = TimeDisplay::new(0, 0);
+
+        let layout = renderer.build_layout(
+            TimerPhase::Stopped,
+            &time_display,
+            None,
+            None,
+            0,
+            0,
+        );
+
+        assert!(layout.line1.contains("停止"));
+    }
+
+    #[test]
+    fn test_layout_renderer_build_progress_bar_zero() {
+        let renderer = LayoutRenderer::new(80);
+        let bar = renderer.build_progress_bar(0, 100);
+        assert!(bar.starts_with('['));
+        assert!(bar.ends_with(']'));
+        assert!(bar.contains('░'));
+    }
+
+    #[test]
+    fn test_layout_renderer_build_progress_bar_half() {
+        let renderer = LayoutRenderer::new(80);
+        let bar = renderer.build_progress_bar(50, 100);
+        assert!(bar.contains('█'));
+        assert!(bar.contains('░'));
+    }
+
+    #[test]
+    fn test_layout_renderer_build_progress_bar_full() {
+        let renderer = LayoutRenderer::new(80);
+        let bar = renderer.build_progress_bar(100, 100);
+        assert!(bar.contains('█'));
+        // Should have no empty chars when 100%
+    }
+
+    #[test]
+    fn test_layout_renderer_build_progress_bar_zero_total() {
+        let renderer = LayoutRenderer::new(80);
+        let bar = renderer.build_progress_bar(50, 0);
+        // When total is 0, should show empty bar
+        assert!(bar.contains('░'));
+        assert!(!bar.contains('█'));
+    }
+
+    #[test]
+    fn test_layout_renderer_phase_style_working() {
+        let (icon, label, color) = LayoutRenderer::phase_style(TimerPhase::Working);
+        assert_eq!(icon, "🍅");
+        assert_eq!(label, "作業中");
+        assert_eq!(color, "red");
+    }
+
+    #[test]
+    fn test_layout_renderer_phase_style_breaking() {
+        let (icon, label, color) = LayoutRenderer::phase_style(TimerPhase::Breaking);
+        assert_eq!(icon, "☕");
+        assert_eq!(label, "休憩中");
+        assert_eq!(color, "green");
+    }
+
+    #[test]
+    fn test_layout_renderer_phase_style_long_breaking() {
+        let (icon, label, color) = LayoutRenderer::phase_style(TimerPhase::LongBreaking);
+        assert_eq!(icon, "🛏️");
+        assert_eq!(label, "長期休憩中");
+        assert_eq!(color, "blue");
+    }
+
+    #[test]
+    fn test_layout_renderer_phase_style_paused() {
+        let (icon, label, color) = LayoutRenderer::phase_style(TimerPhase::Paused);
+        assert_eq!(icon, "⏸️");
+        assert_eq!(label, "一時停止");
+        assert_eq!(color, "yellow");
+    }
+
+    #[test]
+    fn test_layout_renderer_phase_style_stopped() {
+        let (icon, label, color) = LayoutRenderer::phase_style(TimerPhase::Stopped);
+        assert_eq!(icon, "⏹");
+        assert_eq!(label, "停止");
+        assert_eq!(color, "white");
+    }
+
+    #[test]
+    fn test_layout_renderer_set_terminal_width() {
+        let mut renderer = LayoutRenderer::new(80);
+        renderer.set_terminal_width(100);
+        assert_eq!(renderer.terminal_width(), 100);
+        assert_eq!(renderer.bar_width(), 40); // 100 * 0.4 = 40, capped at 40
+    }
+
+    #[test]
+    fn test_layout_renderer_render_standalone() {
+        let renderer = LayoutRenderer::new(80);
+        let layout = DisplayLayout::new(
+            "line1".to_string(),
+            "line2".to_string(),
+            Some("line3".to_string()),
+        );
+
+        let output = renderer.render_standalone(&layout);
+        assert!(output.contains("line1"));
+        assert!(output.contains("line2"));
+        assert!(output.contains("line3"));
+        assert_eq!(output.matches('\n').count(), 2);
+    }
+
+    #[test]
+    fn test_layout_renderer_render_standalone_without_task() {
+        let renderer = LayoutRenderer::new(80);
+        let layout = DisplayLayout::new("line1".to_string(), "line2".to_string(), None);
+
+        let output = renderer.render_standalone(&layout);
+        assert!(output.contains("line1"));
+        assert!(output.contains("line2"));
+        assert_eq!(output.matches('\n').count(), 1);
     }
 }

--- a/src/cli/layout.rs
+++ b/src/cli/layout.rs
@@ -234,11 +234,7 @@ mod tests {
 
     #[test]
     fn test_display_layout_lines_with_task() {
-        let layout = DisplayLayout::new(
-            "a".to_string(),
-            "b".to_string(),
-            Some("c".to_string()),
-        );
+        let layout = DisplayLayout::new("a".to_string(), "b".to_string(), Some("c".to_string()));
         let lines = layout.lines();
         assert_eq!(lines, vec!["a", "b", "c"]);
     }
@@ -342,14 +338,7 @@ mod tests {
         let renderer = LayoutRenderer::new(80);
         let time_display = TimeDisplay::new(0, 1500);
 
-        let layout = renderer.build_layout(
-            TimerPhase::Working,
-            &time_display,
-            None,
-            None,
-            0,
-            1500,
-        );
+        let layout = renderer.build_layout(TimerPhase::Working, &time_display, None, None, 0, 1500);
 
         assert!(layout.line1.contains("作業中"));
         assert_eq!(layout.line2, "");
@@ -362,14 +351,8 @@ mod tests {
         let renderer = LayoutRenderer::new(80);
         let time_display = TimeDisplay::new(60, 300);
 
-        let layout = renderer.build_layout(
-            TimerPhase::Breaking,
-            &time_display,
-            None,
-            None,
-            60,
-            300,
-        );
+        let layout =
+            renderer.build_layout(TimerPhase::Breaking, &time_display, None, None, 60, 300);
 
         assert!(layout.line1.contains("休憩中"));
     }
@@ -379,14 +362,8 @@ mod tests {
         let renderer = LayoutRenderer::new(80);
         let time_display = TimeDisplay::new(0, 900);
 
-        let layout = renderer.build_layout(
-            TimerPhase::LongBreaking,
-            &time_display,
-            None,
-            None,
-            0,
-            900,
-        );
+        let layout =
+            renderer.build_layout(TimerPhase::LongBreaking, &time_display, None, None, 0, 900);
 
         assert!(layout.line1.contains("長期休憩中"));
     }
@@ -396,14 +373,8 @@ mod tests {
         let renderer = LayoutRenderer::new(80);
         let time_display = TimeDisplay::new(500, 1500);
 
-        let layout = renderer.build_layout(
-            TimerPhase::Paused,
-            &time_display,
-            None,
-            None,
-            500,
-            1500,
-        );
+        let layout =
+            renderer.build_layout(TimerPhase::Paused, &time_display, None, None, 500, 1500);
 
         assert!(layout.line1.contains("一時停止"));
     }
@@ -413,14 +384,7 @@ mod tests {
         let renderer = LayoutRenderer::new(80);
         let time_display = TimeDisplay::new(0, 0);
 
-        let layout = renderer.build_layout(
-            TimerPhase::Stopped,
-            &time_display,
-            None,
-            None,
-            0,
-            0,
-        );
+        let layout = renderer.build_layout(TimerPhase::Stopped, &time_display, None, None, 0, 0);
 
         assert!(layout.line1.contains("停止"));
     }

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -237,11 +237,7 @@ mod tests {
         let writer = MockWriter::new();
         let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
 
-        let layout = DisplayLayout::new(
-            "Line 1".to_string(),
-            "Line 2".to_string(),
-            None,
-        );
+        let layout = DisplayLayout::new("Line 1".to_string(), "Line 2".to_string(), None);
 
         controller.render(&layout).unwrap();
 
@@ -279,11 +275,7 @@ mod tests {
         let writer = MockWriter::new();
         let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
 
-        let layout = DisplayLayout::new(
-            "Line 1".to_string(),
-            "Line 2".to_string(),
-            None,
-        );
+        let layout = DisplayLayout::new("Line 1".to_string(), "Line 2".to_string(), None);
         controller.render(&layout).unwrap();
 
         writer.data.lock().unwrap().clear();
@@ -307,11 +299,7 @@ mod tests {
         let writer = MockWriter::new();
         let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
 
-        let layout = DisplayLayout::new(
-            "Line 1".to_string(),
-            "Line 2".to_string(),
-            None,
-        );
+        let layout = DisplayLayout::new("Line 1".to_string(), "Line 2".to_string(), None);
         controller.render(&layout).unwrap();
 
         writer.data.lock().unwrap().clear();
@@ -320,7 +308,7 @@ mod tests {
 
         let content = writer.get_content();
         assert!(content.contains("\x1b[2A")); // MoveUp to previous position
-        // Should contain ClearLine sequences
+                                              // Should contain ClearLine sequences
         assert!(content.matches("\x1b[2K").count() >= 2);
     }
 }

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -1,16 +1,27 @@
+//! ターミナル制御モジュール
+//!
+//! ANSIエスケープシーケンスを使用してターミナル出力を制御する。
+
 use crate::cli::layout::DisplayLayout;
 use std::fmt;
 use std::io::{self, Write};
 use terminal_size::{terminal_size, Height, Width};
 
+/// ANSIエスケープシーケンス
 #[derive(Debug, PartialEq)]
 pub enum AnsiSequence {
-    SaveCursor,    // \x1b[s
-    RestoreCursor, // \x1b[u
-    HideCursor,    // \x1b[?25l
-    ShowCursor,    // \x1b[?25h
-    MoveUp(u16),   // \x1b[nA
-    ClearLine,     // \x1b[2K
+    /// カーソル位置を保存
+    SaveCursor,
+    /// カーソル位置を復元
+    RestoreCursor,
+    /// カーソルを非表示
+    HideCursor,
+    /// カーソルを表示
+    ShowCursor,
+    /// カーソルを上に移動
+    MoveUp(u16),
+    /// 行をクリア
+    ClearLine,
 }
 
 impl fmt::Display for AnsiSequence {
@@ -26,12 +37,14 @@ impl fmt::Display for AnsiSequence {
     }
 }
 
+/// ターミナル出力バッファ
 pub struct TerminalBuffer {
     buffer: String,
     writer: Box<dyn Write + Send>,
 }
 
 impl TerminalBuffer {
+    /// 新しいバッファを作成（stdout使用）
     pub fn new() -> Self {
         Self {
             buffer: String::with_capacity(4096),
@@ -39,6 +52,7 @@ impl TerminalBuffer {
         }
     }
 
+    /// カスタムライターでバッファを作成
     pub fn with_writer(writer: Box<dyn Write + Send>) -> Self {
         Self {
             buffer: String::with_capacity(4096),
@@ -46,11 +60,13 @@ impl TerminalBuffer {
         }
     }
 
+    /// バッファにデータを追加
     pub fn queue<D: fmt::Display>(&mut self, d: D) {
         use std::fmt::Write;
         let _ = write!(self.buffer, "{}", d);
     }
 
+    /// バッファをフラッシュ
     pub fn flush(&mut self) -> io::Result<()> {
         self.writer.write_all(self.buffer.as_bytes())?;
         self.writer.flush()?;
@@ -65,6 +81,7 @@ impl Default for TerminalBuffer {
     }
 }
 
+/// ターミナルコントローラー
 pub struct TerminalController {
     buffer: TerminalBuffer,
     #[allow(dead_code)]
@@ -75,6 +92,7 @@ pub struct TerminalController {
 }
 
 impl TerminalController {
+    /// 新しいコントローラーを作成
     pub fn new() -> Self {
         let (w, h) = if let Some((Width(w), Height(h))) = terminal_size() {
             (w, h)
@@ -90,6 +108,7 @@ impl TerminalController {
         }
     }
 
+    /// カスタムライターでコントローラーを作成（テスト用）
     #[cfg(test)]
     pub fn with_writer(writer: Box<dyn Write + Send>) -> Self {
         Self {
@@ -100,6 +119,7 @@ impl TerminalController {
         }
     }
 
+    /// レイアウトをレンダリング
     pub fn render(&mut self, layout: &DisplayLayout) -> io::Result<()> {
         self.buffer.queue(AnsiSequence::SaveCursor);
         self.buffer.queue(AnsiSequence::HideCursor);
@@ -110,7 +130,7 @@ impl TerminalController {
         }
 
         let mut line_count = 0;
-        for line in &layout.lines {
+        for line in layout.lines() {
             self.buffer.queue(AnsiSequence::ClearLine);
             self.buffer.queue(line);
             self.buffer.queue("\n");
@@ -125,6 +145,7 @@ impl TerminalController {
         self.buffer.flush()
     }
 
+    /// 表示をクリア
     pub fn clear(&mut self) -> io::Result<()> {
         if self.last_line_count > 0 {
             self.buffer
@@ -216,9 +237,11 @@ mod tests {
         let writer = MockWriter::new();
         let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
 
-        let mut layout = DisplayLayout::new();
-        layout.lines.push("Line 1".to_string());
-        layout.lines.push("Line 2".to_string());
+        let layout = DisplayLayout::new(
+            "Line 1".to_string(),
+            "Line 2".to_string(),
+            None,
+        );
 
         controller.render(&layout).unwrap();
 
@@ -233,22 +256,71 @@ mod tests {
     }
 
     #[test]
+    fn test_controller_render_with_task() {
+        let writer = MockWriter::new();
+        let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
+
+        let layout = DisplayLayout::new(
+            "Line 1".to_string(),
+            "Line 2".to_string(),
+            Some("Task line".to_string()),
+        );
+
+        controller.render(&layout).unwrap();
+
+        let content = writer.get_content();
+        assert!(content.contains("Line 1\n"));
+        assert!(content.contains("Line 2\n"));
+        assert!(content.contains("Task line\n"));
+    }
+
+    #[test]
     fn test_controller_render_update() {
         let writer = MockWriter::new();
         let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
 
-        let mut layout = DisplayLayout::new();
-        layout.lines.push("Line 1".to_string());
+        let layout = DisplayLayout::new(
+            "Line 1".to_string(),
+            "Line 2".to_string(),
+            None,
+        );
         controller.render(&layout).unwrap();
 
         writer.data.lock().unwrap().clear();
 
-        layout.lines.push("Line 2".to_string());
-        controller.render(&layout).unwrap();
+        let layout2 = DisplayLayout::new(
+            "Line 1 updated".to_string(),
+            "Line 2 updated".to_string(),
+            Some("New task".to_string()),
+        );
+        controller.render(&layout2).unwrap();
 
         let content = writer.get_content();
-        assert!(content.contains("\x1b[1A"));
-        assert!(content.contains("Line 1\n"));
-        assert!(content.contains("Line 2\n"));
+        assert!(content.contains("\x1b[2A")); // MoveUp(2) for previous 2 lines
+        assert!(content.contains("Line 1 updated\n"));
+        assert!(content.contains("Line 2 updated\n"));
+        assert!(content.contains("New task\n"));
+    }
+
+    #[test]
+    fn test_controller_clear() {
+        let writer = MockWriter::new();
+        let mut controller = TerminalController::with_writer(Box::new(writer.clone()));
+
+        let layout = DisplayLayout::new(
+            "Line 1".to_string(),
+            "Line 2".to_string(),
+            None,
+        );
+        controller.render(&layout).unwrap();
+
+        writer.data.lock().unwrap().clear();
+
+        controller.clear().unwrap();
+
+        let content = writer.get_content();
+        assert!(content.contains("\x1b[2A")); // MoveUp to previous position
+        // Should contain ClearLine sequences
+        assert!(content.matches("\x1b[2K").count() >= 2);
     }
 }


### PR DESCRIPTION
## 概要

Closes #125

インジケーター、時間表示、アニメーション、タスク名を3行構成のレイアウトに統合する`LayoutRenderer`モジュールを実装しました。

## 変更内容

### 新規実装 (`src/cli/layout.rs`)

- **DisplayLayout構造体**: 3行レイアウトのデータ構造
  - `line1`: フェーズ＋プログレスバー＋時間
  - `line2`: アニメーション
  - `line3`: タスク名（オプション）
  - `lines()`, `max_width()`メソッド

- **LayoutRenderer構造体**: レイアウト構築ロジック
  - `build_layout()`: 全コンポーネントを統合
  - `build_progress_bar()`: プログレスバー生成（ターミナル幅の40%、最大40文字）
  - `phase_style()`: フェーズ別アイコン・ラベル・色
  - `render_standalone()`: 独自レンダリング（indicatif非使用時）

### 更新 (`src/cli/terminal.rs`)

- 新しい`DisplayLayout` APIに対応（`layout.lines()`メソッド使用）

## レイアウト構造

```
1行目: 🍅 作業中 ████████░░░░░░░░ 05:23/25:00 (21%)
2行目: 🏃💨 ─────────────────────────────
3行目: タスク: 書類作成（オプション）
```

## テスト結果

- layout関連テスト: 30件 ✅ 全パス
- terminal関連テスト: 7件 ✅ 全パス
- Clippy: ✅ パス
- rustfmt: ✅ パス

## 受け入れ条件

- [x] 3行レイアウト構築成功
- [x] タスク名なしで2行レイアウト
- [x] フェーズ別の色分け（red/green/blue/yellow）
- [x] プログレスバー幅がターミナル幅に応じて調整
- [x] `cargo test layout` が全てパス

## 関連

- 親Epic: #121
- 依存: #122 (TimeFormatter), #123 (AnimationEngine), #124 (TerminalController)
- 設計書: `docs/designs/detailed/visual-enhancement/layout-renderer.md`