### PR TITLE
Wire up EnhancedDisplayState in main.rs for visual enhancement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@
 
 use anyhow::Result;
 use clap::Parser;
-use pomodoro::cli::{generate_completions, Cli, Commands, Display, EnhancedDisplayState, IpcClient};
+use pomodoro::cli::{
+    generate_completions, Cli, Commands, Display, EnhancedDisplayState, IpcClient,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,12 +63,12 @@ async fn main() -> Result<()> {
             }
         },
         Commands::Status => {
-            let mut bar = None;
+            let mut state = EnhancedDisplayState::new();
             loop {
                 match client.status().await {
                     Ok(response) => {
                         if response.status == "success" {
-                            if !display.update_status(response, &mut bar) {
+                            if !display.update_status_enhanced(response, &mut state) {
                                 break;
                             }
                         } else {
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
                         break;
                     }
                 }
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             }
         }
         Commands::Install => match pomodoro::launchagent::install() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Result;
 use clap::Parser;
-use pomodoro::cli::{generate_completions, Cli, Commands, Display, IpcClient};
+use pomodoro::cli::{generate_completions, Cli, Commands, Display, EnhancedDisplayState, IpcClient};
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
## Summary

- Wire up the `EnhancedDisplayState` from Issue #126/#127 to the actual CLI
- Replace old indicatif-based status display with new 3-line layout

## Changes

1. **Import**: Added `EnhancedDisplayState` to imports from `pomodoro::cli`
2. **Status Command**: 
   - Replaced `let mut bar = None;` with `let mut state = EnhancedDisplayState::new();`
   - Replaced `display.update_status(response, &mut bar)` with `display.update_status_enhanced(response, &mut state)`
   - Changed loop interval from `Duration::from_secs(1)` to `Duration::from_millis(200)` for smooth animation

## Before/After

**Before**: Old indicatif progress bar with 1-second updates
**After**: New 3-line flicker-free layout with 200ms animation updates

## Testing

- `cargo check` - Passes
- `cargo test` - All 407 tests pass (350 unit + 57 integration)
- Visual enhancement integration tests (21 tests) all pass

Closes #134