### PR TITLE
fix: 休憩中アニメーションの波の動きを改善

### DIFF
--- a/src/cli/animation.rs
+++ b/src/cli/animation.rs
@@ -63,10 +63,12 @@ impl PhaseAnimation {
     /// 休憩中アニメーション
     pub fn short_break() -> Self {
         let frames = vec![
-            AnimationFrame::new("🧘 ～～～ ゆっくり休憩中 ～～～"),
+            AnimationFrame::new("🧘～～～  ゆっくり休憩中  ～～～"),
+            AnimationFrame::new("🧘 ～～～ ゆっくり休憩中  ～～～"),
+            AnimationFrame::new("🧘  ～～～ゆっくり休憩中  ～～～"),
             AnimationFrame::new("🧘  ～～～ ゆっくり休憩中 ～～～"),
-            AnimationFrame::new("🧘 ～～～  ゆっくり休憩中 ～～～"),
-            AnimationFrame::new("🧘  ～～～ ゆっくり休憩中  ～～～"),
+            AnimationFrame::new("🧘  ～～～ゆっくり休憩中  ～～～"),
+            AnimationFrame::new("🧘 ～～～ ゆっくり休憩中  ～～～"),
         ];
         Self {
             phase: TimerPhase::Breaking,
@@ -186,7 +188,7 @@ mod tests {
 
         let br = PhaseAnimation::short_break();
         assert_eq!(br.phase, TimerPhase::Breaking);
-        assert_eq!(br.frames.len(), 4);
+        assert_eq!(br.frames.len(), 6);
 
         let lbr = PhaseAnimation::long_break();
         assert_eq!(lbr.phase, TimerPhase::LongBreaking);


### PR DESCRIPTION
## 概要
Closes #138

休憩中アニメーションの波（～～～）を左右に揺れるゆったりした動きに改善。

## Root Cause Analysis（根本原因分析）

### 原因
スペースの挿入位置がバラバラで、波がどの方向に動いているか不明瞭だった。

**発生条件**:
- `pomodoro status` 実行時
- 休憩中（Breaking）フェーズ

**根本原因**:
フレーム定義が一貫性に欠けていた。

### 修正内容
波が左から右、右から左へ揺れる6フレームアニメーションに変更。

**変更箇所**:
- `src/cli/animation.rs`: `PhaseAnimation::short_break()` のフレームを再設計

**修正行数**: 6行（1ファイル）

### 影響範囲
休憩中アニメーションの表示のみ

**デグレードリスク**: 低

## Regression Test

### 免除理由
視覚的な表示変更のみ。既存テスト `test_phase_animation_factories` のフレーム数を4→6に更新。

### 全テスト結果
```
test result: ok. 407 passed; 0 failed; 16 ignored
```

## Bugfix Rule遵守チェック

- [x] 最小変更の原則（リファクタリングなし）
  - 変更行数: 6行
  - 判定: ✅ 最小限
- [x] Regression Test
  - 免除: 視覚的変更のみ（テストのフレーム数更新済み）
- [x] 原因記録
  - Root Cause Analysisセクションに記載
- [x] 影響範囲確認
  - 全テスト実行: ✅ 通過