### PR TITLE
fix: break animation with symmetric breathing wave motion

### DIFF
--- a/src/cli/animation.rs
+++ b/src/cli/animation.rs
@@ -60,15 +60,15 @@ impl PhaseAnimation {
         }
     }
 
-    /// 休憩中アニメーション
+    /// 休憩中アニメーション（左右対称の呼吸）
     pub fn short_break() -> Self {
         let frames = vec![
-            AnimationFrame::new("🧘～～～  ゆっくり休憩中  ～～～"),
-            AnimationFrame::new("🧘 ～～～ ゆっくり休憩中  ～～～"),
-            AnimationFrame::new("🧘  ～～～ゆっくり休憩中  ～～～"),
-            AnimationFrame::new("🧘  ～～～ ゆっくり休憩中 ～～～"),
-            AnimationFrame::new("🧘  ～～～ゆっくり休憩中  ～～～"),
-            AnimationFrame::new("🧘 ～～～ ゆっくり休憩中  ～～～"),
+            AnimationFrame::new("🧘～～～    ゆっくり休憩中    ～～～"),
+            AnimationFrame::new("🧘 ～～～   ゆっくり休憩中   ～～～ "),
+            AnimationFrame::new("🧘  ～～～  ゆっくり休憩中  ～～～  "),
+            AnimationFrame::new("🧘   ～～～ ゆっくり休憩中 ～～～   "),
+            AnimationFrame::new("🧘  ～～～  ゆっくり休憩中  ～～～  "),
+            AnimationFrame::new("🧘 ～～～   ゆっくり休憩中   ～～～ "),
         ];
         Self {
             phase: TimerPhase::Breaking,


### PR DESCRIPTION
## 概要
Closes #140

休憩アニメーションの右側の波が固定されていた問題を修正。

## Root Cause Analysis（根本原因分析）

### 原因
`short_break()` のフレーム定義で、右側の波 `～～～` の位置が全フレームで固定されていた。

**発生条件**:
- 休憩フェーズ（Breaking）でアニメーションを表示

**根本原因**:
PR #139 で左側の波のみ修正し、右側の波の位置調整を忘れていた。

### 修正内容
左右対称の「呼吸」アニメーションに変更：
- 両方の波が同時に中央に近づき、同時に離れる
- リラックス感のある呼吸のような動き

**変更箇所**:
- `src/cli/animation.rs`: `short_break()` のフレーム定義を修正

**修正行数**: 7行（1ファイル）

### 影響範囲
休憩フェーズのアニメーション表示のみ。

**デグレードリスク**: 低

## 修正前後の比較

### 修正前（右の波が固定）
```
🧘～～～  ゆっくり休憩中  ～～～  ← 右固定
🧘 ～～～ ゆっくり休憩中  ～～～  ← 右固定
🧘  ～～～ゆっくり休憩中  ～～～  ← 右固定
```

### 修正後（左右対称の呼吸）
```
🧘～～～    ゆっくり休憩中    ～～～  ← 両方外側
🧘 ～～～   ゆっくり休憩中   ～～～   ← 少し内側
🧘  ～～～  ゆっくり休憩中  ～～～    ← 中央寄り
🧘   ～～～ ゆっくり休憩中 ～～～     ← 最も内側
🧘  ～～～  ゆっくり休憩中  ～～～    ← 戻り
🧘 ～～～   ゆっくり休憩中   ～～～   ← 外側へ
```

## テスト結果
```
cargo test --lib -- animation
test result: ok. 9 passed; 0 failed; 0 ignored
```